### PR TITLE
Fixing the file image provider implementation

### DIFF
--- a/lib/lago/__init__.py
+++ b/lib/lago/__init__.py
@@ -505,9 +505,13 @@ class Prefix(object):
             elif spec['type'] == 'file':
                 url = spec.get('url', '')
                 if url:
-                    shutil.move(
-                        self.fetch_url(self.path.prefixed(url)), spec['path']
-                    )
+                    downloaded_path = self.fetch_url(url)
+                    if 'path' in spec:
+                        shutil.move(downloaded_path, spec['path'])
+                    else:
+                        spec['path'] = downloaded_path
+
+                    return self.fetch_url(url), disk_metadata
                 # If we're using raw file, just return it's path
                 return spec['path'], disk_metadata
             else:


### PR DESCRIPTION
Now you if you specify a url and no path in the disk spec, it will
download to the base of the prefix, but if you do, it will move it to
the given path.

Change-Id: I89bc01d322a9ceda8a9de220c957b343e8bebd37
Signed-off-by: Tolik Litovsky <tlitovsk@redhat.com>