### PR TITLE
Fix the cleanup on init failure

### DIFF
--- a/lib/lago/cmd.py
+++ b/lib/lago/cmd.py
@@ -112,7 +112,7 @@ def do_init(
 
         prefix.virt_conf(virt_conf, repo, store)
     except:
-        shutil.rmtree(prefix)
+        shutil.rmtree(prefix.paths.prefixed(''))
         raise
 
 

--- a/scripts/version_manager.py
+++ b/scripts/version_manager.py
@@ -162,8 +162,8 @@ def get_merged_commits(repo, commit, first_parents, children_per_parent):
         next_commit = repo.get_object(next_sha)
         if (
             next_sha not in first_parents and not has_firstparent_child(
-                next_sha, first_parents, children_per_parent)
-            or next_sha in commit.parents
+                next_sha, first_parents, children_per_parent
+            ) or next_sha in commit.parents
         ):
             merge_children.add(next_sha)
 


### PR DESCRIPTION
Before it was not using the prefix path, but the prefix instance, and
thus, failing