### PR TITLE
Adding the ssh timout to the spec

### DIFF
--- a/lib/lago/virt.py
+++ b/lib/lago/virt.py
@@ -652,7 +652,8 @@ class VM(object):
             )
         return utils.CommandStatus(rc, out, err)
 
-    def wait_for_ssh(self, connect_retries=50):
+    def wait_for_ssh(self):
+        connect_retries = self._spec.get('boot_time_sec', 50)
         while connect_retries:
             ret, _, _ = self.ssh(['true'])
             if ret == 0:
@@ -936,6 +937,7 @@ class VM(object):
                 'root-partition',
                 'root',
             )
+
             g = guestfs.GuestFS(python_return_dict=True)
             g.add_drive_opts(disk_path, format='qcow2', readonly=1)
             g.set_backend('direct')


### PR DESCRIPTION
This patch will allow long booting machines to operate too
Like the ovirt engine appliance first boot

Change-Id: Id85f29b8fdf026e2910c326f2e2c9dce82f467aa
Signed-off-by: Tolik Litovsky <tlitovsk@redhat.com>