### PR TITLE
Ova ovirt support

### DIFF
--- a/lib/lago/__init__.py
+++ b/lib/lago/__init__.py
@@ -462,8 +462,6 @@ class Prefix(object):
             LOGGER.debug("Spec: %s" % spec)
             disk_metadata = {}
 
-            disk_metadata = {}
-
             disk_filename = '%s_%s.%s' % (name, spec['name'], spec['format'])
             disk_path = self.paths.images(disk_filename)
             if spec['type'] == 'template':
@@ -506,6 +504,7 @@ class Prefix(object):
                 url = spec.get('url', '')
                 path = spec.get('path', '')
 
+                disk_metadata = spec.get('metadata',{})
                 if not url and not path:
                     raise RuntimeError('Partial drive spec %s' % str(spec))
 
@@ -620,12 +619,16 @@ class Prefix(object):
                     image_file = item["rasd:HostResource"]
 
         if image_file is not None:
+            disk_meta ={"root-partition":"/dev/sda1"}
+
             disk_spec = [{"type": "file",
                           "format": "qcow2",
                           "dev": "vda",
+                          "name": "root",
                           "name": os.path.basename(image_file),
                           "path": ova_extracted_dir +
-                                 "/images/" + image_file}]
+                                 "/images/" + image_file,
+                          "metadata": disk_meta }]
 
         return disk_spec, memory, vcpus
 

--- a/lib/lago/__init__.py
+++ b/lib/lago/__init__.py
@@ -702,7 +702,7 @@ class Prefix(object):
                     if "disks" not in spec.keys():
                         spec["disks"] = ova_disk
                     else:
-                        spec["disks"] = spec["disks"] + ova_disk
+                        spec["disks"] = ova_disk + spec["disks"]
 
                 new_disks = []
                 spec['name'] = name

--- a/lib/lago/virt.py
+++ b/lib/lago/virt.py
@@ -652,7 +652,8 @@ class VM(object):
             )
         return utils.CommandStatus(rc, out, err)
 
-    def wait_for_ssh(self, connect_retries=50):
+    def wait_for_ssh(self):
+        connect_retries = self._spec.get('boot_time_sec', 50)
         while connect_retries:
             ret, _, _ = self.ssh(['true'])
             if ret == 0:
@@ -936,6 +937,7 @@ class VM(object):
                 'root-partition',
                 'root',
             )
+
             g = guestfs.GuestFS(python_return_dict=True)
             g.add_drive_opts(disk_path, format='qcow2', readonly=1)
             g.set_backend('direct')

--- a/lib/lago/virt.py
+++ b/lib/lago/virt.py
@@ -531,6 +531,7 @@ class VM(object):
     def __init__(self, env, spec):
         self._env = env
         self._spec = self._normalize_spec(spec.copy())
+
         self._service_class = _SERVICE_WRAPPERS.get(
             self._spec.get('service_class', None),
             None,


### PR DESCRIPTION
This patch will allow the ovirt contrib plugin to handle the ova disk properly
It will be able to find the correct rootfs in the correct disk order