### PR TITLE
Moving from sftp to scp for copy to/from vms

### DIFF
--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -9,6 +9,7 @@ python-lxml
 python-magic
 python-nose
 python-paramiko
+python-scp
 python-xmltodict
 python2-devel
 yum

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ autodoc_mock_imports = [
     'rpmUtils',
     'rpmUtils.arch',
     'rpmUtils.miscutils',
+    'scp',
     'stevedore',
     'stevedore.extension',
     'xmltodict',

--- a/lago.spec.in
+++ b/lago.spec.in
@@ -16,6 +16,7 @@ BuildRequires:	python-nose
 BuildRequires:	git
 Requires:	python-%{name} = %{version}
 Requires:	sudo
+Requires:	python-scp
 
 %description
 LAGO System testing framework.

--- a/lib/lago/virt.py
+++ b/lib/lago/virt.py
@@ -32,6 +32,7 @@ import guestfs
 import libvirt
 import lxml.etree
 import paramiko
+from scp import SCPClient
 
 import config
 import brctl
@@ -672,25 +673,24 @@ class VM(object):
             )
 
     @contextlib.contextmanager
-    def _sftp(self):
+    def _scp(self):
         client = self._get_ssh_client()
-        sftp = client.open_sftp()
+        scp = SCPClient(client.get_transport())
         try:
-            yield sftp
+            yield scp
         finally:
-            sftp.close()
             client.close()
 
     def copy_to(self, local_path, remote_path):
         with LogTask(
             'Copy %s to %s:%s' % (local_path, self.name(), remote_path),
         ):
-            with self._sftp() as sftp:
-                sftp.put(local_path, remote_path)
+            with self._scp() as scp:
+                scp.put(local_path, remote_path)
 
     def copy_from(self, remote_path, local_path):
-        with self._sftp() as sftp:
-            sftp.get(remote_path, local_path)
+        with self._scp() as scp:
+            scp.get(remote_path, local_path)
 
     @property
     def metadata(self):


### PR DESCRIPTION
That allows using hosts that don't have sftp server installed, like
the small cirros/busybox images that use dropbear for ssh

Fixes #79

Change-Id: I3734ad048953a2a40f7eb0d4b86c0b751ac35f1d
Signed-off-by: David Caro <dcaroest@redhat.com>