### PR TITLE
Fix changed file detection

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -7,7 +7,7 @@ code_changed() {
         echo "Not in a git dir, will run all the tests"
         return 0
     fi
-    git diff-tree --no-commit-id --name-only -r HEAD \
+    git diff-tree --no-commit-id --name-only -r HEAD..HEAD^ \
     | grep --quiet -v -e '\(docs/\|README.md\)'
     return $?
 }


### PR DESCRIPTION
Now it compares the current commit with it's first parent, instead of
just looking for changes in the current commit (that worked when not
using merge commits).

Change-Id: I9614bec1e931c35fbf9298db69cc6c58ffa13b9f
Signed-off-by: David Caro <dcaroest@redhat.com>