### PR TITLE
Add ovirt Node VM support

### DIFF
--- a/contrib/ovirt/lib/ovirtlago/__init__.py
+++ b/contrib/ovirt/lib/ovirtlago/__init__.py
@@ -388,6 +388,7 @@ class OvirtPrefix(lago.Prefix):
 
     @_with_repo_server
     def run_test(self, path):
+
         with LogTask('Run test: %s' % os.path.basename(path)):
             env = os.environ.copy()
             env['LAGO_PREFIX'] = self.paths.prefix()
@@ -436,10 +437,14 @@ class OvirtPrefix(lago.Prefix):
 
     def _deploy_host(self, host):
         with LogTask('Deploy VM %s' % host.name()):
+            ovirt_scripts = host.metadata.get('ovirt-scripts', [])
+            if not ovirt_scripts:
+                return
+
             with LogTask('Wait for ssh connectivity'):
                 host.wait_for_ssh()
 
-            for script in host.metadata.get('ovirt-scripts', []):
+            for script in ovirt_scripts:
                 with LogTask('Run script %s' % os.path.basename(script)):
                     ret, out, err = host.ssh_script(script, show_output=False)
 

--- a/contrib/ovirt/lib/ovirtlago/virt.py
+++ b/contrib/ovirt/lib/ovirtlago/virt.py
@@ -43,6 +43,9 @@ class OvirtVirtEnv(lago.virt.VirtEnv):
         elif role == 'host':
             self._host_vms.append(HostVM(self, vm_spec))
             return self._host_vms[-1]
+        elif role == 'node':
+            self._host_vms.append(NodeVM(self, vm_spec))
+            return self._host_vms[-1]
         else:
             return TestVM(self, vm_spec)
 
@@ -51,6 +54,18 @@ class OvirtVirtEnv(lago.virt.VirtEnv):
 
     def host_vms(self):
         return self._host_vms[:]
+
+
+# TODO : solve the problem of ssh to the Node
+class NodeVM(lago.virt.VM):
+    def _artifact_paths(self):
+        return []
+
+    def collect_artifacts(self, host_path):
+        return
+
+    def wait_for_ssh(self):
+        return
 
 
 class TestVM(lago.virt.VM):


### PR DESCRIPTION
This is combined from two patches
Node VM that avoid ssh connection and artefact collection
And avoiding the SSH connection when no scripts exist

Change-Id: I45df7d5ac92d68526ff5a034471aef73399a61af
Signed-off-by: Tolik Litovsky <tlitovsk@redhat.com>