### PR TITLE
Fix wrong import of TaskLogNosePlugin

### DIFF
--- a/contrib/ovirt/lib/ovirtlago/__init__.py
+++ b/contrib/ovirt/lib/ovirtlago/__init__.py
@@ -26,7 +26,6 @@ import lockfile
 import nose.core
 import nose.config
 from ovirtsdk.infrastructure.errors import RequestError
-
 import lago
 from lago import log_utils
 
@@ -422,7 +421,7 @@ class OvirtPrefix(lago.Prefix):
                 stream=DummyStream(),
             )
             addplugins = [
-                log_utils.TaskLogNosePlugin(),
+                testlib.TaskLogNosePlugin(),
                 testlib.LogCollectorPlugin(self),
             ]
             result = nose.core.run(


### PR DESCRIPTION
Change-Id: I49cf26295736286fc5538af1c3ea8049b111319b
Signed-off-by: David Caro <dcaroest@redhat.com>