### PR TITLE
Add two RuntimeError exceptions: add the URL of a failed download.

### DIFF
--- a/contrib/ovirt/lib/ovirtlago/repoverify.py
+++ b/contrib/ovirt/lib/ovirtlago/repoverify.py
@@ -107,7 +107,13 @@ def fetch_xml(url):
     Returns:
         lxml.etree._Element: Root of the xml tree for the retrieved resource
     """
-    content = urllib2.urlopen(url).read()
+    try:
+        content = urllib2.urlopen(url).read()
+    except urllib2.URLError, e:
+        raise RuntimeError(
+            'Failed to open URL %s\nError code: %s\nError Reason: %s' %
+            (url, e.code, e.reason)
+        )
 
     if url.endswith('.gz'):
         content = gzip.GzipFile(fileobj=StringIO.StringIO(content)).read()

--- a/lib/lago/templates.py
+++ b/lib/lago/templates.py
@@ -154,7 +154,14 @@ class HttpTemplateProvider:
             except RuntimeError:
                 pass
         full_url = posixpath.join(self.baseurl, url) + suffix
-        response = urllib.urlopen(full_url)
+        try:
+            response = urllib.urlopen(full_url)
+        except urllib.error.URLError, e:
+            raise RuntimeError(
+                'Failed to open URL %s\nError code: %s\nError Reason: %s' %
+                (url, e.code, e.reason)
+            )
+
         if response.code >= 300:
             raise RuntimeError(
                 'Failed no retrieve URL %s:\nCode: %d' %

--- a/lib/lago/templates.py
+++ b/lib/lago/templates.py
@@ -156,10 +156,10 @@ class HttpTemplateProvider:
         full_url = posixpath.join(self.baseurl, url) + suffix
         try:
             response = urllib.urlopen(full_url)
-        except urllib.error.URLError, e:
+        except IOError, e:
             raise RuntimeError(
                 'Failed to open URL %s\nError code: %s\nError Reason: %s' %
-                (url, e.code, e.reason)
+                (url, e.errno, e.strerror)
             )
 
         if response.code >= 300:

--- a/lib/lago/templates.py
+++ b/lib/lago/templates.py
@@ -187,7 +187,13 @@ class HttpTemplateProvider:
 
         if dest:
             response.close()
-            urllib.urlretrieve(full_url, dest, report)
+            try:
+                urllib.urlretrieve(full_url, dest, report)
+            except IOError, e:
+                raise RuntimeError(
+                    'Failed to retrieve URL %s\nError code: %s\nError Reason: %s'
+                    % (full_url, e.errno, e.strerror)
+                )
             sys.stdout.write("\n")
         return response
 

--- a/lib/lago/templates.py
+++ b/lib/lago/templates.py
@@ -159,7 +159,7 @@ class HttpTemplateProvider:
         except IOError, e:
             raise RuntimeError(
                 'Failed to open URL %s\nError code: %s\nError Reason: %s' %
-                (url, e.errno, e.strerror)
+                (full_url, e.errno, e.strerror)
             )
 
         if response.code >= 300:

--- a/lib/lago/templates.py
+++ b/lib/lago/templates.py
@@ -191,8 +191,8 @@ class HttpTemplateProvider:
                 urllib.urlretrieve(full_url, dest, report)
             except IOError, e:
                 raise RuntimeError(
-                    'Failed to retrieve URL %s\nError code: %s\nError Reason: %s'
-                    % (full_url, e.errno, e.strerror)
+                    'Failed to retrieve URL %s\nError code: %s\n \
+                    Error Reason: %s' % (full_url, e.errno, e.strerror)
                 )
             sys.stdout.write("\n")
         return response


### PR DESCRIPTION
1. Of a template.
2. Of a repo metadata file.
I got both on ovirtmaster testing right now. 


For example:
```
  # Create disks for VM lago_basic_suite_master_engine: ERROR (in 0:04:14)
@ Initialize and populate prefix: ERROR (in 0:04:15)
Error occured, aborting
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/lago/cmd.py", line 447, in main
    cli_plugins[args.verb].do_run(args)
  File "/usr/lib/python2.7/site-packages/lago/plugins/cli.py", line 180, in do_run
    self._do_run(**vars(args))
  File "/usr/lib/python2.7/site-packages/lago/log_utils.py", line 598, in wrapper
    func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/lago/cmd.py", line 113, in do_init
    prefix.virt_conf(virt_conf, repo, store)
  File "/usr/lib/python2.7/site-packages/lago/__init__.py", line 739, in virt_conf
    template_store,
  File "/usr/lib/python2.7/site-packages/lago/__init__.py", line 485, in _create_disk
    template_store.download(template_version)
  File "/usr/lib/python2.7/site-packages/lago/templates.py", line 646, in download
    temp_ver.download(temp_dest)
  File "/usr/lib/python2.7/site-packages/lago/templates.py", line 518, in download
    self._source.download_image(self._handle, destination)
  File "/usr/lib/python2.7/site-packages/lago/templates.py", line 203, in download_image
    self.open_url(url=handle, dest=dest)
  File "/usr/lib/python2.7/site-packages/lago/templates.py", line 160, in open_url
    raise RuntimeError('Failed to open URL %s' % (full_url))
RuntimeError: Failed to open URL http://10.35.18.63/repo/centos7/engine/v5.qcow2
```