### PR TITLE
Added --prefix-path option to the lago command

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -126,7 +126,10 @@ def do_init(
 def in_prefix(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        prefix_path = lago_prefix.resolve_prefix_path()
+        prefix_path = kwargs.get('prefix_path', 'auto')
+        if prefix_path == 'auto':
+            prefix_path = lago_prefix.resolve_prefix_path()
+
         return func(*args, prefix=lago_prefix.Prefix(prefix_path), **kwargs)
 
     return wrapper
@@ -485,6 +488,12 @@ def create_parser(cli_plugins, out_plugins):
         action='store',
         default='default',
         choices=out_plugins.keys(),
+    )
+    parser.add_argument(
+        '--prefix-path',
+        '-p',
+        action='store',
+        default='auto',
     )
     verbs_parser = parser.add_subparsers(dest='verb', metavar='VERB')
     for cli_plugin_name, cli_plugin in cli_plugins.items():

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -44,7 +44,10 @@ DISTS = ['el6', 'el7', 'fc20']
 def in_prefix(func):
     @functools.wraps(func)
     def wrapper(args):
-        prefix_path = lago.prefix.resolve_prefix_path()
+        prefix_path = getattr(args, 'prefix_path', 'auto')
+        if prefix_path == 'auto':
+            prefix_path = lago.prefix.resolve_prefix_path()
+
         prefix = ovirtlago.OvirtPrefix(prefix_path)
         return func(prefix, args)
 

--- a/tests/functional/basic.bats
+++ b/tests/functional/basic.bats
@@ -148,6 +148,32 @@ is_initialized() {
 }
 
 
+@test "basic.full_run: status when stopped explicitly specifying the prefix" {
+    local prefix="$FIXTURES"/prefix1
+
+    is_initialized "$prefix" || skip "prefix not initiated"
+    helpers.run "$LAGOCLI" --prefix-path "$prefix" status
+    helpers.equals "$status" '0'
+    echo "$output" \
+    | tail -n+2 \
+    > "$prefix/current"
+    echo "DIFF:Checking if the output differs from the expected"
+    echo "CURRENT                  | EXPECTED"
+    expected_content="$FIXTURES/expected_down_status"
+    expected_file="expected_down_status"
+    sed \
+        -e "s|@@BATS_TEST_DIRNAME@@|$BATS_TEST_DIRNAME|g" \
+        "$expected_content" \
+    > "$expected_file"
+    diff \
+        --suppress-common-lines \
+        --side-by-side \
+        "$prefix/current" \
+        "$expected_file"
+}
+
+
+
 @test "basic.full_run: start everything at once" {
     local prefix="$FIXTURES"/prefix1
 


### PR DESCRIPTION
This allows to explicitly override the automatic discovery of the
prefix path it should be working on

Change-Id: If440b6b5d7d8cf457abe7bf4727fa405fc692c1a
Signed-off-by: David Caro <dcaroest@redhat.com>