### PR TITLE
Added ignore-warnings option

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -27,6 +27,7 @@ import os
 import pkg_resources
 import shutil
 import sys
+import warnings
 
 import lago
 import lago.config
@@ -494,6 +495,7 @@ def create_parser(cli_plugins, out_plugins):
         action='store',
         default='auto',
     )
+    parser.add_argument('--ignore-warnings', action='store_true', )
     verbs_parser = parser.add_subparsers(dest='verb', metavar='VERB')
     for cli_plugin_name, cli_plugin in cli_plugins.items():
         plugin_parser = verbs_parser.add_parser(
@@ -506,7 +508,7 @@ def create_parser(cli_plugins, out_plugins):
 
 def check_group_membership():
     if 'lago' not in [grp.getgrgid(gid).gr_name for gid in os.getgroups()]:
-        LOGGER.warning('current session does not belong to lago group.')
+        warnings.warn('current session does not belong to lago group.')
 
 
 def main():
@@ -530,6 +532,12 @@ def main():
             )
         )
     ]
+
+    logging.captureWarnings(True)
+    if args.ignore_warnings:
+        logging.getLogger('py.warnings').setLevel(logging.ERROR)
+    else:
+        warnings.formatwarning = lambda message, *args, **kwargs: message
 
     check_group_membership()
 

--- a/tests/functional/basic.bats
+++ b/tests/functional/basic.bats
@@ -102,6 +102,16 @@ FIXTURES="$FIXTURES/basic"
 }
 
 
+@test "basic.full_run: ignore-warnings hides the group warning" {
+    local prefix="$FIXTURES"/prefix1
+
+    common.is_initialized "$prefix" || skip "prefix not initiated"
+    pushd "$prefix" >/dev/null
+    helpers.run_ok "$LAGOCLI" --ignore-warnings status
+    helpers.diff_output_nowarning "$FIXTURES/expected_down_status"
+}
+
+
 @test "basic.full_run: status when stopped explicitly specifying the prefix" {
     local prefix="$FIXTURES"/prefix1
 
@@ -109,7 +119,6 @@ FIXTURES="$FIXTURES/basic"
     helpers.run_ok "$LAGOCLI" --prefix-path "$prefix" status
     helpers.diff_output "$FIXTURES/expected_down_status"
 }
-
 
 
 @test "basic.full_run: start everything at once" {


### PR DESCRIPTION
Also moved to use the python stdlib warnings module, that allows us to
use deprecation warnings and handle them properly.

Change-Id: Ib2891696d6c04b2d9f5567413b769d94c46db7c9
Signed-off-by: David Caro <dcaroest@redhat.com>