### PR TITLE
Ignore zero sized RPM files when merging repos.

### DIFF
--- a/ovirtlago/merge_repos.py
+++ b/ovirtlago/merge_repos.py
@@ -67,6 +67,8 @@ def merge(output_dir, input_dirs):
                     input_dir,
                     '-type',
                     'f',
+                    '-size',
+                    '+0',
                     '-name',
                     '*.rpm',
                 ]


### PR DESCRIPTION
For some reason (unsuccesful downloads?) I got empty RPM files.
They were merged with other (good) files and I had those as RPMs.
Obviously, they failed to install.
The search for the RPMs now ignores such files and thus merges only REAL files.