### PR TITLE
Remove the memory balloon device. We don't use it.

### DIFF
--- a/lago/dom_template.xml
+++ b/lago/dom_template.xml
@@ -16,6 +16,7 @@
     </features>
     <devices>
       <emulator>@QEMU_KVM@</emulator>
+      <memballoon model='none'/>
       <disk type='file' device='disk'>
         <driver name='qemu' type='qcow2'/>
         <source file='DISK_PATH'/>


### PR DESCRIPTION
The less devices the better. 
(I'm wondering what else we can remove, move to virtio, etc.)