### PR TITLE
Added config defaults to code

### DIFF
--- a/etc/lago.d/lago.conf
+++ b/etc/lago.d/lago.conf
@@ -3,5 +3,5 @@ log_level = debug
 template_store = /var/lib/lago/store
 template_repos = /var/lib/lago/repos
 default_root_password = 123456
-ssh_tries = 50
+ssh_tries = 100
 ssh_timeout = 10

--- a/lago/config.py
+++ b/lago/config.py
@@ -24,6 +24,14 @@ import os
 
 _SYSTEM_CONFIG_DIR = '/etc/lago.d'
 _USER_CONFIG = os.path.join(os.path.expanduser('~'), '.lago')
+DEFAULTS = {
+    'log_level': 'debug',
+    'template_store': '/var/lib/lago/store',
+    'template_repos': '/var/lib/lago/repos',
+    'default_root_password': '123456',
+    'ssh_tries': '100',
+    'ssh_timeout': '10',
+}
 
 
 def _get_environ():
@@ -35,7 +43,7 @@ def _get_from_env(key):
 
 
 def _get_from_files(paths, key):
-    config = ConfigParser.ConfigParser()
+    config = ConfigParser.ConfigParser(defaults=DEFAULTS)
     config.read(paths)
     try:
         return config.get('lago', key)


### PR DESCRIPTION
That way if we introduce a new conf value and the local conf file was
modified, an upgrade will not make lago throw 'missing key' error, but
get the default from the defaults in the code itself

Fixes #187

Change-Id: I9d20f91a3789a9068a0bafdecfb6e1e974219a01
Signed-off-by: David Caro <dcaroest@redhat.com>