### PR TITLE
Showing extra logs on sysprep errors

### DIFF
--- a/lago/sysprep.py
+++ b/lago/sysprep.py
@@ -126,4 +126,11 @@ def sysprep(disk, mods, backend='direct'):
 
     ret = utils.run_command(cmd, env=env)
     if ret:
-        raise RuntimeError('Failed to bootstrap %s' % disk)
+        raise RuntimeError(
+            'Failed to bootstrap %s\ncommand:%s\nstdout:%s\nstderr:%s' % (
+                disk,
+                ' '.join('"%elem"' % elem for elem in cmd),
+                ret.out,
+                ret.err,
+            )
+        )


### PR DESCRIPTION
For example, when bootstrapping a disk

Change-Id: I614cb9e1aee96f0008bb5d013492c15c5cf0da51
Signed-off-by: David Caro <dcaroest@redhat.com>