### PR TITLE
Fixed string interpolation when showing sysprep error

### DIFF
--- a/lago/sysprep.py
+++ b/lago/sysprep.py
@@ -129,7 +129,7 @@ def sysprep(disk, mods, backend='direct'):
         raise RuntimeError(
             'Failed to bootstrap %s\ncommand:%s\nstdout:%s\nstderr:%s' % (
                 disk,
-                ' '.join('"%elem"' % elem for elem in cmd),
+                ' '.join('"%s"' % elem for elem in cmd),
                 ret.out,
                 ret.err,
             )


### PR DESCRIPTION
Change-Id: I0a44e5551b10b71362cec1c2698900463f00c3fe
Signed-off-by: David Caro <dcaroest@redhat.com>