### PR TITLE
Differentiate alive and defined VM

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -325,7 +325,9 @@ def do_shell(prefix, host, args=None, **kwargs):
         raise
 
     if not host.alive():
-        raise RuntimeError('Host %s is not running' % host.name())
+        raise RuntimeError(
+            'Host %s is not "running", but "%s"' % (host.name(), host.state())
+        )
 
     host.wait_for_ssh()
 
@@ -483,7 +485,9 @@ def do_copy_from_vm(prefix, host, remote_path, local_path, **kwargs):
         raise
 
     if not host.alive():
-        raise RuntimeError('Host %s is not running' % host.name())
+        raise RuntimeError(
+            'Host %s is not "running", but "%s"' % (host.name(), host.state())
+        )
 
     host.wait_for_ssh()
     host.copy_from(remote_path, local_path)
@@ -523,7 +527,9 @@ def do_copy_to_vm(prefix, host, remote_path, local_path, **kwargs):
         raise
 
     if not host.alive():
-        raise RuntimeError('Host %s is not running' % host.name())
+        raise RuntimeError(
+            'Host %s is not "running", but "%s"' % (host.name(), host.state())
+        )
 
     host.wait_for_ssh()
     host.copy_to(local_path, remote_path)

--- a/tests/unit/lago/test_virt.py
+++ b/tests/unit/lago/test_virt.py
@@ -35,10 +35,10 @@ def mocked_methods():
 
 
 @pytest.fixture()
-def mock_VM(is_alive, mocked_methods, monkeypatch):
+def mock_VM(is_defined, mocked_methods, monkeypatch):
     mocks = {}
-    if 'alive' not in mocked_methods:
-        mocked_methods['alive'] = lambda *args: is_alive
+    if 'defined' not in mocked_methods:
+        mocked_methods['defined'] = lambda *args: is_defined
 
     mock_vm_cls = mock.Mock(spec=lago.virt.VM)
 
@@ -66,15 +66,15 @@ def mock_VM(is_alive, mocked_methods, monkeypatch):
 
 class TestVM(object):
     @pytest.mark.parametrize(
-        'is_alive,mocked_methods',
+        'is_defined,mocked_methods',
         (
             (True, {'state': lago.virt.VM.state}),
             (False, {'state': lago.virt.VM.state}),
         ),
-        ids=('alive VM', 'dead VM'),
+        ids=('defined VM', 'dead VM'),
     )
     def test_state(self, mock_VM):
-        if mock_VM.alive():
+        if mock_VM.defined():
             assert mock_VM.state() == 'shrubbery'
         else:
             assert mock_VM.state() == 'down'


### PR DESCRIPTION
Alive means that it's running, defined that it's defined in libvirt,
but on any other state.

Fixes #203

Change-Id: I1b1d1e06e67eb6ed2b978fc3762c7b4096868a4e
Signed-off-by: David Caro <dcaroest@redhat.com>