### PR TITLE
Few fixes to virt.py

### DIFF
--- a/lago/dom_template.xml
+++ b/lago/dom_template.xml
@@ -7,7 +7,7 @@
     </cpu>
     <os>
       <type arch='x86_64' machine='pc'>hvm</type>
-      <bootmenu enable='yes'/>
+      <bootmenu enable='no'/>
     </os>
     <features>
       <acpi/>
@@ -18,11 +18,14 @@
       <emulator>@QEMU_KVM@</emulator>
       <memballoon model='none'/>
       <disk type='file' device='disk'>
-        <driver name='qemu' type='qcow2'/>
+        <driver name='qemu' type='qcow2' io='native' discard='unmap'/>
         <source file='DISK_PATH'/>
         <target dev='DISK_DEV' bus='virtio'/>
       </disk>
       <graphics type='vnc' port='-1' autoport='yes' listen='0.0.0.0' keymap='en-us'/>
+      <video>
+        <model type='qxl'/>
+      </video>
       <channel type='unix'>
         <source mode='bind'/>
         <target type='virtio' name='org.qemu.guest_agent.0'/>


### PR DESCRIPTION
1. Copy artificats from live VMs only via SCP:
- This substantially improve artifacts collection time.
2. Add discard and native IO attributes to the QEMU disk driver
3. Move some SSH initialization code from within loops
4. Switch video to QXL (supposed to be better)
5. Switch cdrom form IDE to SCSI (supposed to be better)
6. Disabled bootmenu

Tested with 3.6 and master.