### PR TITLE
Fixed repoverify not behaving like reposync

### DIFF
--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -7,6 +7,8 @@ python-virtualenv
 python-libguestfs
 libxslt-devel
 libvirt-devel
+libffi-devel
+openssl-devel
 yum
 # needed for fc23
 # see http://pkgs.fedoraproject.org/cgit/libguestfs.git/tree/libguestfs.spec#n131

--- a/automation/check-patch.packages.fc23
+++ b/automation/check-patch.packages.fc23
@@ -7,6 +7,8 @@ python-virtualenv
 python-libguestfs
 libxslt-devel
 libvirt-devel
+libffi-devel
+openssl-devel
 dnf-command(builddep)
 # needed for fc23
 # see http://pkgs.fedoraproject.org/cgit/libguestfs.git/tree/libguestfs.spec#n131


### PR DESCRIPTION
Now it's behaving as reposync, matching both the name and
name+version+arch when filtering in and out packages.

Change-Id: I88266d01e8980b240b9fa0ad65efc836d11cb1a5
Signed-off-by: David Caro <dcaroest@redhat.com>