### PR TITLE
Fixed wrong error log on reposetup

### DIFF
--- a/ovirtlago/merge_repos.py
+++ b/ovirtlago/merge_repos.py
@@ -21,6 +21,7 @@
 import logging
 import os
 import shutil
+import sys
 from functools import partial
 
 import utils
@@ -42,7 +43,8 @@ def merge(output_dir, input_dirs):
     try:
         os.makedirs(output_dir)
     except:
-        pass
+        sys.exc_clear()
+
     for input_dir in input_dirs:
         with LogTask('Processing directory %s' % input_dir):
             ret = utils.run_command(


### PR DESCRIPTION
If the repos dir already existed, the reposetup log would show error
because the exception was not being cleared from the sys.exc_info
stack before starting the log task

Change-Id: Icb599df0d96f1efe330b824a973bc96e2dccf693
Signed-off-by: David Caro <dcaroest@redhat.com>