### PR TITLE
Add prefix env vars

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -992,6 +992,7 @@ class Prefix(object):
                 host.wait_for_ssh()
 
             for script in deploy_scripts:
+                script = os.path.expanduser(os.path.expandvars(script))
                 with LogTask('Run script %s' % os.path.basename(script)):
                     ret, out, err = host.ssh_script(script, show_output=False)
 

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -497,7 +497,11 @@ def in_prefix(prefix_class, workdir_class):
                     prefix = workdir.get_prefix(prefix_name)
                     kwargs['perfix_name'] = prefix_name
 
+                prefix_path = os.path.join(workdir_path, prefix_name)
+
             kwargs['prefix'] = prefix
+            os.environ['LAGO_PREFIX_PATH'] = prefix_path or ''
+            os.environ['LAGO_WORKDIR_PATH'] = workdir_path or ''
             return func(*args, **kwargs)
 
         return wrapper

--- a/tests/functional/fixtures/deploy/suite_1host.yaml
+++ b/tests/functional/fixtures/deploy/suite_1host.yaml
@@ -11,8 +11,8 @@ domains:
           format: qcow2
       metadata:
         deploy-scripts:
-          - scripts/create_nicefile.sh
-          - scripts/create_uglyfile.sh
+          - $LAGO_PREFIX_PATH/../../scripts/create_nicefile.sh
+          - $LAGO_WORKDIR_PATH/../scripts/create_uglyfile.sh
 
 nets:
   lago_functional_tests:


### PR DESCRIPTION
Now you can use variables on the deploy scripts paths, and some vars are added to allow relocatable prefixes