### PR TITLE
Add tags and cscope.out to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ AUTHORS
 */*venv
 .bash*
 .cache*
+tags
+cscope.out


### PR DESCRIPTION
'cscope.out' and 'tags' are both generated by tools that help navigating
Python codebase (pycscope and ctags respectively) and should be ignored
by git.