### PR TITLE
Process domains in the same consistent order of domains.

### DIFF
--- a/lago/utils.py
+++ b/lago/utils.py
@@ -17,6 +17,7 @@
 #
 # Refer to the README and COPYING files for full details of the license
 #
+import copy
 import Queue
 import collections
 import datetime
@@ -419,6 +420,10 @@ def deepcopy(original_obj):
     """
     if isinstance(original_obj, list):
         return list(deepcopy(item) for item in original_obj)
+    elif isinstance(original_obj, collections.OrderedDict):
+        return collections.OrderedDict(
+            (key, deepcopy(val)) for key, val in original_obj.items()
+        )
     elif isinstance(original_obj, dict):
         return dict((key, deepcopy(val)) for key, val in original_obj.items())
     else:
@@ -437,12 +442,14 @@ def load_virt_stream(virt_fd):
         dict: Loaded virt config
     """
     try:
-        virt_conf = json.load(virt_fd)
+        virt_conf = json.load(
+            virt_fd, object_pairs_hook=collections.OrderedDict
+        )
     except ValueError:
         virt_fd.seek(0)
         virt_conf = yaml.load(virt_fd)
 
-    return deepcopy(virt_conf)
+    return copy.deepcopy(virt_conf)
 
 
 def in_prefix(prefix_class, workdir_class):

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -17,6 +17,7 @@
 #
 # Refer to the README and COPYING files for full details of the license
 #
+import collections
 import functools
 import hashlib
 import json
@@ -86,11 +87,11 @@ class VirtEnv(object):
         with open(self.prefix.paths.uuid(), 'r') as uuid_fd:
             self.uuid = uuid_fd.read().strip()
 
-        self._nets = {}
+        self._nets = collections.OrderedDict()
         for name, spec in net_specs.items():
             self._nets[name] = self._create_net(spec)
 
-        self._vms = {}
+        self._vms = collections.OrderedDict()
         for name, spec in vm_specs.items():
             self._vms[name] = self._create_vm(spec)
 
@@ -235,17 +236,21 @@ class VirtEnv(object):
         virt_path = functools.partial(prefix.paths.prefixed, 'virt')
 
         with open(virt_path('env'), 'r') as f:
-            env_dom = json.load(f)
+            env_dom = json.load(f, object_pairs_hook=collections.OrderedDict)
 
-        net_specs = {}
+        net_specs = collections.OrderedDict()
         for name in env_dom['nets']:
             with open(virt_path('net-%s' % name), 'r') as f:
-                net_specs[name] = json.load(f)
+                net_specs[name] = json.load(
+                    f, object_pairs_hook=collections.OrderedDict
+                )
 
-        vm_specs = {}
+        vm_specs = collections.OrderedDict()
         for name in env_dom['vms']:
             with open(virt_path('vm-%s' % name), 'r') as f:
-                vm_specs[name] = json.load(f)
+                vm_specs[name] = json.load(
+                    f, object_pairs_hook=collections.OrderedDict
+                )
 
         return cls(prefix, vm_specs, net_specs)
 


### PR DESCRIPTION
In order to process domains in the order they are in the JSON file,
I've changed all relevant dicts to collections.OrderedDicts as well as
loaded the JSON with the proper settings to keep it ordered.

Testing both oVirt 3.6 and master show that now domains are processed
in a consistent manner: engine, storage, host0, host1