### PR TITLE
Perform domain name check when creating mapping entry for the given network (part of #36)

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -311,9 +311,18 @@ class Prefix(object):
 
         Returns:
             None
+
+        Raises:
+            RuntimeError: If the provided domain name is empty string
         """
         dom_name = dom['name']
         idx = dom['nics'].index(nic)
+        if not dom_name:
+            raise RuntimeError(
+                'Invalid (empty) domain name. A name must be specified for '
+                'the domain'
+            )
+
         name = idx == 0 and dom_name or '%s-eth%d' % (dom_name, idx)
         net['mapping'][name] = nic['ip']
 


### PR DESCRIPTION
As noted in https://github.com/lago-project/lago/issues/36 so far lago will happily attempt to init a prefix 
even in the case the domain name wasn't provided (is empty string). If such a domain references a network, attempt to start such a network will subsequently end up with an exception in the form similar to the one below:
```
Error occured, aborting
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/lago/cmd.py", line 691, in main
    cli_plugins[args.verb].do_run(args)
  File "/usr/lib/python2.7/site-packages/lago/plugins/cli.py", line 180, in do_run
    self._do_run(**vars(args))
  File "/usr/lib/python2.7/site-packages/lago/utils.py", line 584, in wrapper
    return func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/lago/utils.py", line 595, in wrapper
    return func(*args, prefix=prefix, **kwargs)
  File "/usr/lib/python2.7/site-packages/lago/cmd.py", line 255, in do_start
    prefix.start(vm_names=vm_names)
  File "/usr/lib/python2.7/site-packages/lago/prefix.py", line 949, in start
    self.virt_env.start(vm_names=vm_names)
  File "/usr/lib/python2.7/site-packages/lago/virt.py", line 189, in start
    net.start()
  File "/usr/lib/python2.7/site-packages/lago/virt.py", line 355, in start
    self._env.libvirt_con.networkCreateXML(self._libvirt_xml())
  File "/usr/lib64/python2.7/site-packages/libvirt.py", line 4093, in networkCreateXML
    if ret is None:raise libvirtError('virNetworkCreateXML() failed', conn=self)
libvirtError: XML error: Cannot use host name '-eth0' in network '4386-930e31b9b9'
```
This is because ```-eth0``` isn't a valid host name (attempt to parse the DHCP host name XML entry by libvirt will fail on the following code part https://libvirt.org/git/?p=libvirt.git;a=blob;f=src/conf/network_conf.c;h=48f39c7540873495c5bae8db77ff56a2414ea6b7;hb=HEAD#l949 ) since in this case the host name isn't starting with alphabetic character (first char is hyphen).

So yet before we could possibly attempt to start a network with invalid hostname, perform a check if provided domain name isn't empty right in the moment of creating network spec mapping entry record for that domain. Raise RuntimeError if domain name wasn't provided.

Part of #36

Please review.

Thank you, Jan