### PR TITLE
Detect (and report) any empty domain name possibly found in the Lago's configuration file sooner

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -312,18 +312,9 @@ class Prefix(object):
 
         Returns:
             None
-
-        Raises:
-            RuntimeError: If the provided domain name is empty string
         """
         dom_name = dom['name']
         idx = dom['nics'].index(nic)
-        if not dom_name:
-            raise RuntimeError(
-                'Invalid (empty) domain name. A name must be specified for '
-                'the domain'
-            )
-
         name = idx == 0 and dom_name or '%s-eth%d' % (dom_name, idx)
         net['mapping'][name] = nic['ip']
 
@@ -829,6 +820,13 @@ class Prefix(object):
             os.makedirs(self.paths.images())
 
         for name, domain_spec in conf['domains'].items():
+            if not name:
+                raise RuntimeError(
+                    'An invalid (empty) domain name was found in the '
+                    'configuration file. Cannot continue. A name must be '
+                    'specified for the domain'
+                )
+
             domain_spec['name'] = name
             conf['domains'][name] = self._prepare_domain_image(
                 domain_spec=domain_spec,


### PR DESCRIPTION
This is a followup / improvement of https://github.com/lago-project/lago/commit/5339d06d72eecf3b155ac35f5aa8b79a38f96d22 in the sense that if empty domain
name was specified in the Lago's configuration yaml / json file, the prefix initialization
will abandon sooner (not already in the moment we attempt to start network for such
an invalid domain, but rather immediately after prefix initialization - in the stage of
preparing vm images for the domain)

Fixes: #36#issuecomment-221348959

Please review.

Thank you, Jan