### PR TITLE
Check memory requirements of the domains (part of #8)

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -938,6 +938,7 @@ class Prefix(object):
                 vm_specs=conf['domains'],
                 net_specs=conf['nets'],
             )
+            self._virt_env.check_memory_requirements(conf)
             if do_bootstrap:
                 self.virt_env.bootstrap()
 


### PR DESCRIPTION
When initializing a prefix Lago currently doesn't perform a domain memory requirements prescan
to verify subsequent call of `lago start` will truly succeed (the sum of memory requirements by
the domains is less than system memory provided by the virtualization host).

Attempt to start Lago domains on such host ends up with `libvirt` exception in the form:
`libvirtError: Could not allocate memory ...` The issue is in this moment some of the networks
might have been already created (and started), thus even allocating more memory on the guest (running the Lago infrastructure) and rerunning the init, might end up with a message that it
wasn't possible to create and launch the network, since it already exists.

Therefore perform check if memory requirements of particular domains could be satisfied by
this virtualization host (libvirt connect). Raise an error (abort `lago init` if not). If requirements
are satisfied, the change will print info message about actually required amount of memory, and
also count of available memory as provided by the virtualization host.

Part of: https://github.com/lago-project/lago/issues/8 (though not in the doc, rather notification by lago init run itself)

Please review.

Thank you, Jan.
