### PR TITLE
libvirt: add auth

### DIFF
--- a/etc/lago.d/lago.conf
+++ b/etc/lago.d/lago.conf
@@ -8,3 +8,5 @@ ssh_timeout = 10
 ssh_tries = 100
 template_repos = /var/lib/lago/repos
 template_store = /var/lib/lago/store
+libvirt_username =
+libvirt_password =

--- a/lago/config.py
+++ b/lago/config.py
@@ -36,6 +36,8 @@ DEFAULTS = {
     'ssh_tries': '100',
     'template_repos': '/var/lib/lago/repos',
     'template_store': '/var/lib/lago/store',
+    'libvirt_username': '',
+    'libvirt_password': '',
 }
 
 


### PR DESCRIPTION
Previously, lago could not work with libvirt that required auth. This
can be problematic for people working with projects that do use
authentication in libvirt, one example being VDMS.

We therefore allow setting of libvirt username and password in
lago.conf, and use these values to authenticate. Default values are
empty, therefore not expecting any form of authentication.