### PR TITLE
Add sanlock log to log collection

### DIFF
--- a/ovirtlago/virt.py
+++ b/ovirtlago/virt.py
@@ -172,4 +172,4 @@ class HostVM(lago.vm.DefaultVM):
         if self.distro() not in ['fc22', 'fc23']:
             inherited_artifacts.append('/var/log/messages')
 
-        return set(inherited_artifacts + ['/var/log/vdsm', ])
+        return set(inherited_artifacts + ['/var/log/vdsm', '/var/log/sanlock.log', ])


### PR DESCRIPTION
This PR adds /var/log/sanlock.log to be collected from the hosts.