### PR TITLE
Changing the ssh connection waiting method

### DIFF
--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -360,7 +360,7 @@ class VMPlugin(plugins.Plugin):
         return ssh.wait_for_ssh(
             ip_addr=self.ip(),
             host_name=self.name(),
-            connect_retries=self._spec.get('boot_time_sec', 50),
+            connect_timeout=self._spec.get('boot_time_sec', 600),
             ssh_key=self.virt_env.prefix.paths.ssh_id_rsa(),
             username=self._spec.get('ssh-user'),
             password=self._spec.get('ssh-password'),

--- a/lago/ssh.py
+++ b/lago/ssh.py
@@ -99,13 +99,14 @@ def ssh(
 def wait_for_ssh(
     ip_addr,
     host_name=None,
-    connect_retries=50,
+    connect_timeout=600,    # 10 minutes
     ssh_key=None,
     username='root',
     password='123456',
 ):
     host_name = host_name or ip_addr
-    while connect_retries:
+    start_time = time.time()
+    while (time.time() - start_time) < connect_timeout:
         try:
             ret, _, _ = ssh(
                 ip_addr=ip_addr,
@@ -128,7 +129,7 @@ def wait_for_ssh(
 
         if ret == 0:
             break
-        connect_retries -= 1
+
         time.sleep(1)
     else:
         # Try one last time, using the ssh default timeout values, as we


### PR DESCRIPTION
The the current 'wait_for_ssh' method is based on TCP timeout (the default ssh timeout in lago is 10 sec)
when the host is booting, while it doesn't get an IP the timeout is really 10 sec,
but between the time it gets it's IP to the time it opens port 22 the timeout is 0.

So, if one of my vms need more time to open port 22 and start sshd, it might fail after 50 retries.

This fix focus on the maximal 'wait-time' Lago will wait until the host can be reached,
instead of the number of retries, that may vary with different OS.

Signed-off-by: Ido Rosenzwig <irosenzw@redhat.com>