### PR TITLE
reposetup: be more verbose on reposync failure

### DIFF
--- a/ovirtlago/reposetup.py
+++ b/ovirtlago/reposetup.py
@@ -129,8 +129,12 @@ def sync_rpm_repository(repo_path, yum_config, repos):
         )
         shutil.rmtree('%s/cache' % repo_path)
         with LogTask('Rerunning reposync a last time'):
-            ret, _, _ = run_command(reposync_command)
+            ret, out, err = run_command(reposync_command)
         if ret:
+            LOGGER.error(
+                'reposync command failed with following output: %s\n'
+                'and following error: %s', out, err
+            )
             raise RuntimeError(
                 'Failed to run reposync a second time, aborting'
             )


### PR DESCRIPTION
Added error logging on reposync retry error.
If something prevent the reposync to complete while
running in jenkins it becomes hard to understand what failed
without having the output of the reposync command.
This patch add stdout and stderr from reposync command
to be printed before aborting the sync.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>