### PR TITLE
Adding lago info

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -35,6 +35,7 @@ import lago.plugins.cli
 import lago.templates
 from lago import (log_utils, workdir as lago_workdir, )
 from lago.utils import (in_prefix, with_logging)
+import lago.info
 
 LOGGER = logging.getLogger('cli')
 in_lago_prefix = in_prefix(
@@ -576,6 +577,39 @@ def do_collect(prefix, output, **kwargs):
 @with_logging
 def do_deploy(prefix, **kwargs):
     prefix.deploy()
+
+
+@lago.plugins.cli.cli_plugin(help='Show info about virtual resources')
+@lago.plugins.cli.cli_plugin_add_argument(
+    'requested_vms',
+    nargs='*',
+    help='The names of the vms to query, if no name is specified, '
+    'all the vms in the env will be query',
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '-a',
+    '--attribute',
+    dest='attribute',
+    required=True,
+    action='store',
+    choices=['ip'],
+    help='List requested information about the virtual resources'
+)
+@in_lago_prefix
+@with_logging
+def do_info(prefix, attribute, requested_vms, out_format, **kwargs):
+    if requested_vms:
+        requested_vms = prefix.virt_env.get_vms_by_name(requested_vms)
+    else:
+        requested_vms = prefix.virt_env.get_vms().values()
+
+    func = getattr(lago.info.Info, attribute)
+    print out_format.format(
+        func(
+            prefix=prefix, requested_vms=requested_vms,
+            **kwargs
+        )
+    )
 
 
 def create_parser(cli_plugins, out_plugins):

--- a/lago/info.py
+++ b/lago/info.py
@@ -1,0 +1,10 @@
+class Info:
+    @staticmethod
+    def ip(prefix, requested_vms, **kwargs):
+        output = []
+        for vm in requested_vms:
+            line = [vm.name()]
+            for nic in vm.nics():
+                line.append('{}:{}'.format(nic['net'], nic.get('ip', 'N/A')))
+                output.append(','.join(line))
+        return output

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -230,6 +230,18 @@ class VirtEnv(object):
     def get_vm(self, name):
         return self._vms[name]
 
+    def get_vms_by_name(self, names):
+        vm_pool = set(names)
+        requested_vms = []
+        for vm_name in vm_pool:
+            if vm_name not in self._vms.keys():
+                LOGGER.info('Available vms:\n' + '\n'.join(self._vms.keys()))
+                raise RuntimeError('vm {} does not exist'.format(vm_name))
+
+            requested_vms.append(self._vms[vm_name])
+
+        return requested_vms
+
     @classmethod
     def from_prefix(cls, prefix):
         virt_path = functools.partial(prefix.paths.prefixed, 'virt')

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ lago.plugins.cli =
     status=lago.cmd:do_status
     stop=lago.cmd:do_stop
     template-repo=lago_template_repo:TemplateRepoCLI
+    info=lago.cmd:do_info
 
 lago.plugins.output =
     default=lago.plugins.output:DefaultOutFormatPlugin


### PR DESCRIPTION
With this command the user can get
info about the virtual resources (all of them, or some
of them by specifying a list of names)

For now, this command will supply
just the info about the ip adresses
of the vms.

Adding additional attribute for query will be done
in 2 steps:

1. Adding the attribute name to the list of 'choices' of 
'-a / --attribute' argument.
2. Creating a function with the name of the new attribute in info.py.
this function should return a data structure with the required 
information, that could be parsed by the output plugins. 

Signed-off-by: gbenhaim <galbh2@gmail.com>