### PR TITLE
Added flat output formatter

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ lago.plugins.output =
     default=lago.plugins.output:DefaultOutFormatPlugin
     json=lago.plugins.output:JSONOutFormatPlugin
     yaml=lago.plugins.output:YAMLOutFormatPlugin
+    flat=lago.plugins.output:FlatOutFormatPlugin
 
 lago.plugins.vm =
     default=lago.vm:DefaultVM


### PR DESCRIPTION
The output of this formatter is not
nested text as in yaml and json, and thus
grep friendly.

The outpust looks the same as a list of
file paths, but instead of files the path
consist of the env's attributes.

Signed-off-by: gbenhaim <galbh2@gmail.com>