### PR TITLE
Removed redundant checks when getting ovirt api

### DIFF
--- a/ovirtlago/virt.py
+++ b/ovirtlago/virt.py
@@ -112,26 +112,29 @@ class EngineVM(lago.vm.DefaultVM):
             insecure=True,
         )
 
-    def _get_api(self, wait):
-        if wait:
-            self.wait_for_ssh()
-            try:
-                testlib.assert_true_within_long(
-                    lambda: self.service('ovirt-engine').alive()
-                )
+    def _get_api(self):
+        try:
+            api = []
 
-                api = []
-                testlib.assert_true_within_short(
-                    lambda: api.append(self._create_api()) or True,
-                    allowed_exceptions=[RequestError, ConnectionError],
-                )
-            except AssertionError:
-                raise RuntimeError('Failed to connect to the engine')
+            def get():
+                instance = self._create_api()
+                if instance:
+                    api.append(instance)
+                    return True
+                return False
+
+            testlib.assert_true_within_short(
+                get,
+                allowed_exceptions=[RequestError, ConnectionError],
+            )
+        except AssertionError:
+            raise RuntimeError('Failed to connect to the engine')
+
         return api.pop()
 
-    def get_api(self, wait=True):
+    def get_api(self):
         if self._api is None or not self._api.test():
-            self._api = self._get_api(wait)
+            self._api = self._get_api()
         return self._api
 
     def add_iso(self, path):


### PR DESCRIPTION
wait parameter should had to be set to true
in order for any code to be executed in '_get_api',
so it is not needed.

Removed engine's service check in order to
support a situation when we can't check for the
service stauts, but https connection is available.

I think that there is a sense in trying to request
the api within a time window, instead of giving up
on first failure, So I kept the request inside
'assert_true_within_short'.

I had to remove the 'or' condition, otherwise
if '_create_api()' returns false, the condition will
be evaluated to true, which in turn will break the
loop of 'assert_true_within'. Eventually we will end
up without api object.

Signed-off-by: gbenhaim <galbh2@gmail.com>