### PR TITLE
Add DNS and IPv6 support

### DIFF
--- a/lago/net_nat_template.xml
+++ b/lago/net_nat_template.xml
@@ -6,5 +6,8 @@
     </nat>
   </forward>
   <bridge name='@BR_NAME@' stp='on' delay='0' />
+  <dns forwardPlainNames='yes' >
+  </dns>
   <ip address='@GW_ADDR@' netmask='255.255.255.0' />
+  <ip family='ipv6' address='fd8f:1391:3a82:5e0d::1' prefix='64' />
 </network>

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -511,7 +511,7 @@ def rotate_dir(base_dir):
     shutil.move(base_dir, add_timestamp_suffix(base_dir))
 
 
-def ip_to_mac(ip):
+def ipv4_to_mac(ip):
     # Mac addrs of domains are 54:52:xx:xx:xx:xx where the last 4 octets are
     # the hex repr of the IP address)
     mac_addr_pieces = [0x54, 0x52] + [int(y) for y in ip.split('.')]

--- a/lago/vm.py
+++ b/lago/vm.py
@@ -122,7 +122,7 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
                     ] + [
                         sysprep.config_net_interface_dhcp(
                             'eth%d' % index,
-                            utils.ip_to_mac(nic['ip']),
+                            utils.ipv4_to_mac(nic['ip']),
                         )
                         for index, nic in enumerate(self.vm._spec['nics'])
                         if 'ip' in nic
@@ -314,7 +314,7 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
             if 'ip' in dev_spec:
                 interface.append(
                     lxml.etree.Element(
-                        'mac', address=utils.ip_to_mac(dev_spec['ip'])
+                        'mac', address=utils.ipv4_to_mac(dev_spec['ip'])
                     ),
                 )
             devices.append(interface)


### PR DESCRIPTION
This commit adds both IPv6 (via DHCP DUID-LL) and DNS support to Lago.

- To add a DNS domain name, use dns_domain_name=example.com to the spec.

- IPv6 is added automatically.
Currently, it is using DUID-LL which means that in order
to get an address, run 'dhclient -6 -D LL' in the domain.

ovirt-system-tests will be enhanced to use the DNS support later on.

Tested with 3.6, 4.0, master.