### PR TITLE
virtio-scsi support in Lago

### DIFF
--- a/lago/dom_template.xml
+++ b/lago/dom_template.xml
@@ -2,12 +2,13 @@
     <name>@NAME@</name>
     <memory unit='MiB'>@MEM_SIZE@</memory>
     <vcpu>@VCPU@</vcpu>
+    <iothreads>1</iothreads>
     <cpu mode='host-passthrough'>
       <topology sockets='@CPU@' cores='1' threads='1'/>
     </cpu>
     <os>
       <type arch='x86_64' machine='pc'>hvm</type>
-      <bootmenu enable='yes'/>
+      <bootmenu enable='no'/>
     </os>
     <features>
       <acpi/>
@@ -17,6 +18,11 @@
     <devices>
       <emulator>@QEMU_KVM@</emulator>
       <memballoon model='none'/>
+      <controller type='usb' model='none'>
+      </controller>
+      <controller type='scsi' index='0' model='virtio-scsi'>
+        <driver iothread='1'/>
+      </controller>
       <disk type='file' device='disk'>
         <driver name='qemu' type='qcow2'/>
         <source file='DISK_PATH'/>

--- a/lago/vm.py
+++ b/lago/vm.py
@@ -265,6 +265,10 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
                 bus = 'ide'
             # names converted
 
+            # support virtio-scsi - sdX devices
+            if dev_spec['dev'].startswith('sd'):
+                bus = 'scsi'
+
             disk = lxml.etree.Element(
                 'disk',
                 type='file',
@@ -276,6 +280,7 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
                     'driver',
                     name='qemu',
                     type=dev_spec['format'],
+                    discard='unmap',
                 ),
             )
 


### PR DESCRIPTION
1. Removed the USB controller - and added virtio-SCSI controller
with a single dedicated IO thread assigned to it.
2. Removed the bootmenu - did not see a need for it.
3. If a disk begins with sd (for example, 'sda') - assume it's SCSI.
4. Unconditionally add 'discard' support. It works for IDE, virtio-scsi.
It works (though does nothing) with virtio-blk.

Tested by converting some ovirt-system-tests to use sdX drives.
By running 'fstrim' inside the guests saw a good reduction in size of disks.

Note: the root disk cannot be virtio-scsi - requires a change in the lago-image.