### PR TITLE
Add serial number to disks.

### DIFF
--- a/lago/vm.py
+++ b/lago/vm.py
@@ -284,6 +284,10 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
                 ),
             )
 
+            serial = lxml.etree.SubElement(disk, 'serial')
+            serial.text = "{}".format(disk_order + 1)
+            disk.append(serial)
+
             disk.append(
                 lxml.etree.Element(
                     'boot', order="{}".format(disk_order + 1)


### PR DESCRIPTION
Apparently, when using SCSI disks, you can't trust the order
UDEV will see them and enumarate them.
The only correct way is use /dev/disk/by-id/...

This adds a serial number to the disk, to make it possible.
Use /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_2 for the 1st SCSI disk, etc.