### PR TITLE
Adding boot menu

### DIFF
--- a/lago/dom_template.xml
+++ b/lago/dom_template.xml
@@ -8,7 +8,7 @@
     </cpu>
     <os>
       <type arch='x86_64' machine='pc'>hvm</type>
-      <bootmenu enable='no'/>
+      <bootmenu enable='yes'/>
     </os>
     <features>
       <acpi/>


### PR DESCRIPTION
After removing the boot menu in
af1c52d679634180b7468e1a69ac5ea218c74fc1
We experinced failures when running check-patch
locally on our laptops. The tests were failed
on ssh timeout, which caused by a faulty network
configuraion of the vm (running ip addr flush dev eth0;
ifup eth0; inside the vm solved the network issue).

Still have to investigate how does the 'boot menu' relates
to the network configuration, but for now this patch fix
the problem.

Signed-off-by: gbenhaim <galbh2@gmail.com>