### PR TITLE
Add host CPU model detection

### DIFF
--- a/lago/virt.py
+++ b/lago/virt.py
@@ -93,6 +93,11 @@ class VirtEnv(object):
             libvirt_url=libvirt_url,
         )
 
+    def get_cpu_model(self):
+        cap_tree = lxml.etree.fromstring(self.libvirt_con.getCapabilities())
+        cpu_model = cap_tree.xpath('/capabilities/host/cpu/model')[0].text
+        return cpu_model
+
     def _create_net(self, net_spec):
         if net_spec['type'] == 'nat':
             cls = NATNetwork

--- a/ovirtlago/virt.py
+++ b/ovirtlago/virt.py
@@ -33,6 +33,7 @@ class OvirtVirtEnv(lago.virt.VirtEnv):
     def __init__(self, prefix, vm_specs, net_spec):
         self._engine_vm = None
         self._host_vms = []
+        self._ovirt_cpu_family = None
         super(OvirtVirtEnv, self).__init__(prefix, vm_specs, net_spec)
 
     def _create_vm(self, vm_spec):
@@ -75,6 +76,31 @@ class OvirtVirtEnv(lago.virt.VirtEnv):
 
     def host_vms(self):
         return self._host_vms[:]
+
+    def get_ovirt_cpu_family(self):
+        ovirt_cpu_families = {
+            'Broadwell': 'Intel Broadwell Family',
+            'Broadwell-noTSX': 'Intel Broadwell-noTSX Family',
+            'Haswell': 'Intel Haswell Family',
+            'Haswell-noTSX': 'Intel Haswell-noTSX Family',
+            'SandyBridge': 'Intel SandyBridge Family',
+            'Westmere': 'Intel Westmere Family',
+            'Nehalem': 'Intel Nehalem Family',
+            'Penryn': 'Intel Penryn Family',
+            'Conroe': 'Intel Conroe Family',
+            'Opteron_G5': 'AMD Opteron G5',
+            'Opteron_G4': 'AMD Opteron G4',
+            'Opteron_G3': 'AMD Opteron G3',
+            'Opteron_G2': 'AMD Opteron G2',
+            'Opteron_G1': 'AMD Opteron G1',
+        }
+
+        if self._ovirt_cpu_family is None:
+            cpu_model = super(OvirtVirtEnv, self).get_cpu_model()
+            self._ovirt_cpu_family = ovirt_cpu_families.get(
+                cpu_model, ovirt_cpu_families['Conroe']
+            )
+        return self._ovirt_cpu_family
 
 
 # TODO : solve the problem of ssh to the Node


### PR DESCRIPTION
Added a function to detect the host CPU (that libvirt knows about).
Added a function that calculates the ovirt CPU family level.

This will later be used in ovirt-system-tests to set cluster
CPU type.

Tested with Haswell and Broadwell CPUs, on master
and hosted-engine ovirt-system-tests.