### PR TITLE
Add ansible playbook to install lago and system-tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,27 @@ Hello, this describes how to get started with Lago.
 Installation
 ----------------
 
+There are 2 installation methods:
+ - ansible-playbook
+ - manual
+
+
+Install using ansible-playbook
+------------------------------
+
+Use simple `hosts.ini` with `lago` section::
+
+ [lago]
+ my.lago.host
+
+, and run the playbook::
+
+ ansible-playbook -i hosts.ini ansible/lago-install.yml
+
+
+Manual installation
+-------------------
+
 In order to install the framework, you'll need to build RPMs or acquire them
 from a repository.
 

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,15 @@
+lago-install.yml playbook will setup a machine with lago and
+ovirt-system-tests as noted down in the README.rst
+
+To run it, set your hosts.ini with a lago section:
+
+```ini
+ [lago]
+  my.lago.host
+```
+
+,and run the playbook:
+
+```bash
+ansible-playbook -i hosts.ini ansible/lago-install.yml
+```

--- a/ansible/lago-el.repo
+++ b/ansible/lago-el.repo
@@ -1,0 +1,5 @@
+[lago]
+baseurl=http://resources.ovirt.org/repos/lago/stable/0.0/rpm/el$releasever
+name=Lago
+enabled=1
+gpgcheck=0

--- a/ansible/lago-install.yml
+++ b/ansible/lago-install.yml
@@ -1,0 +1,54 @@
+---
+- name: Install lago and ovirt system-tests on a machine (Follows the README.md instructions)
+  hosts: lago
+  remote_user: root
+  tasks:
+    - name: Create the lago yum repositories
+      copy:
+        src: lago-el.repo
+        dest: /etc/yum.repos.d/lago-el.repo
+
+    - name: Create ovirt-ci-tools repo
+      copy:
+        src: ovirt-ci-tools.repo
+        dest: /etc/yum.repos.d/ovirt-ci-tools.repo
+
+    - name: Install lago and dependencies
+      yum: name={{ item }} state=present
+      with_items:
+        - lago
+        - lago-ovirt
+        - python-lago
+        - python-lago-ovirt
+        - http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm
+        - https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+    - name: Configure nested virtualization
+      modprobe: name=kvm_intel state=present params="nested=y"
+
+    - name: Configure services
+      service: name=libvirtd enabled=yes state=started
+
+    - name: Disable selinux
+      selinux: policy=targeted state=permissive
+
+    - name: ovirt user setup
+      user: name=ovirt shell=/bin/bash groups=lago,qemu append=yes
+
+    - name: ovirt path permissions
+      file: path=/home/ovirt state=directory mode="g+x"
+
+    - name: qemu user setup
+      user: name=qemu shell=/bin/bash groups=ovirt append=yes
+
+    - name: Libvirtd restart
+      service: name=libvirtd state=restarted
+
+    - name: Override lago.conf
+      template: src=lago.conf.j2 dest=/etc/lago.d/lago.conf
+
+    - name: Clone ovirt system-tests
+      git:
+        repo: git://gerrit.ovirt.org/ovirt-system-tests
+        dest: /home/ovirt/ovirt-system-tests
+      become_user: ovirt

--- a/ansible/lago.conf.j2
+++ b/ansible/lago.conf.j2
@@ -1,0 +1,7 @@
+[lago]
+log_level = debug
+template_store = /home/ovirt/lago/store
+template_repos = /home/ovirt/lago/repos
+lease_dir = /home/ovirt/lago/subnets
+#default_root_password = 123456
+

--- a/ansible/lago.el.repo
+++ b/ansible/lago.el.repo
@@ -1,0 +1,5 @@
+[lago]
+baseurl=http://resources.ovirt.org/repos/lago/stable/0.0/rpm/el$releasever
+name=Lago
+enabled=1
+gpgcheck=0

--- a/ansible/lago.install.yml
+++ b/ansible/lago.install.yml
@@ -1,0 +1,54 @@
+---
+- name: Install lago and ovirt system-tests on a machine (Follows the README.md instructions)
+  hosts: lago
+  remote_user: root
+  tasks:
+    - name: Create the lago yum repositories
+      copy:
+        src: lago.el.repo
+        dest: /etc/yum.repos.d/lago.el.repo
+
+    - name: Create ovirt-ci-tools repo
+      copy:
+        src: ovirt-ci-tools.repo
+        dest: /etc/yum.repos.d/epel.repo
+
+    - name: Install lago and dependencies
+      yum: name={{ item }} state=present
+      with_items:
+        - lago
+        - lago-ovirt
+        - python-lago
+        - python-lago-ovirt
+        - http://resources.ovirt.org/pub/yum-repo/ovirt-release40.rpm
+        - https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+    - name: Configure nested virtualization
+      modprobe: name=kvm_intel state=present params="nested=y"
+
+    - name: Configure services
+      service: name=libvirtd enabled=yes state=started
+
+    - name: Disable selinux
+      selinux: policy=targeted state=permissive
+
+    - name: ovirt user setup
+      user: name=ovirt shell=/bin/bash groups=lago,qemu append=yes
+
+    - name: ovirt path permissions
+      file: path=/home/ovirt state=directory mode="g+x"
+
+    - name: qemu user setup
+      user: name=qemu shell=/bin/bash groups=ovirt append=yes
+
+    - name: Libvirtd restart
+      service: name=libvirtd state=restarted
+
+    - name: Override lago.conf
+      template: src=lago.conf.j2 dest=/etc/lago.d/lago.conf
+
+    - name: Clone ovirt system-tests
+      git:
+        repo: git://gerrit.ovirt.org/ovirt-system-tests
+        dest: /home/ovirt/ovirt-system-tests
+      become_user: ovirt

--- a/ansible/ovirt-ci-tools.repo
+++ b/ansible/ovirt-ci-tools.repo
@@ -1,0 +1,5 @@
+[ovirt-ci-tools]
+baseurl=http://resources.ovirt.org/repos/ci-tools/el$releasever
+name=ovirt-ci-tools
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
The added playbook allows setting up a machine with lago and
ovirt-system-tests as noted down in the README.md

To run it, set your `hosts.ini` with a `lago` section:

``` ini
 [lago]
 my.lago.host
```

and run the playbook:

``` bash
 ansible-playbook -i hosts.ini ansible/lago.install.yml
```

Signed-off-by: Roy Golan rgolan@redhat.com
