### PR TITLE
Moving over get_prefixed_name() to ovirtlago/testlib

### DIFF
--- a/ovirtlago/testlib.py
+++ b/ovirtlago/testlib.py
@@ -46,6 +46,13 @@ def get_test_prefix():
     return _test_prefix
 
 
+def get_prefixed_name(entity_name):
+    suite = os.environ.get('SUITE')
+    return (
+        'lago-' + os.path.basename(suite).replace('.', '-') + '-' + entity_name
+    )
+
+
 def with_ovirt_prefix(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
This is more useful than having it copied around in multiple tests.
Just a handy function.

After it'll be included in a released Lago, will convert
ovirt-system-tests to use it.