### PR TITLE
Change to repoman options

### DIFF
--- a/ovirtlago/__init__.py
+++ b/ovirtlago/__init__.py
@@ -226,14 +226,14 @@ class OvirtPrefix(Prefix):
 
             rpm_dirs.extend(
                 [
-                    os.path.join(folder, dist) + ':only-missing'
+                    os.path.join(folder, dist)
                     for folder in project_roots if os.path.exists(folder)
                 ]
             )
 
             rpm_dirs.extend(
                 [
-                    os.path.join(repos_path, name) + ':only-missing'
+                    os.path.join(repos_path, name)
                     for name in repo_names if name.endswith(dist)
                 ],
             )

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -138,8 +138,8 @@ def do_ovirt_runtest(prefix, test_file, **kwargs):
 @cli_plugin_add_argument(
     '--custom-source',
     help=(
-        'Add an extra rpm source to the repo (will have priority over the '
-        'repos), allows any source string allowed by repoman'
+        'Add an extra rpm source to the repo '
+        '(allows any source string allowed by repoman)'
     ),
     dest='custom_sources',
     action='append',


### PR DESCRIPTION
This change allows repoman to collect
multiple versions of the same package into
the internal repo of the prefix.

Currently packages are being taken to the
internal repo in the following order:
1. sources that were specified using '--custom-source'.
2. Packages from the repos that were specified in the
   reposync-config file (passed to lago with --reposync-yum-config).
   Note: currently, the order in the config matters, for example:
   only package 'x.n' from the first repo will be added to the internal
   repo, even if package 'x.n+1' is in the second repo.

This situation causes unwanted behaviour when there are multiple
versions of the same package in different repos, and this change
is meant to fix it.

Signed-off-by: gbenhaim galbh2@gmail.com
