### PR TITLE
Fix exception occuring while using "list" command

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -52,7 +52,7 @@ in_lago_prefix = in_prefix(
         'Configuration of resources to deploy, json and yaml file formats '
         'are supported, takes option precedence over workdir. Will use '
         '$PWD/LagoInitFile by default. You can use any env vars in that file, '
-        'inculuding the extra ones LAGO_PREFIX_PATH LAGO_WORKDIR_PATH and '
+        'including the extra ones LAGO_PREFIX_PATH LAGO_WORKDIR_PATH and '
         'LAGO_INITFILE_PATH'
     ),
     metavar='VIRT_CONFIG',

--- a/lago/plugins/output.py
+++ b/lago/plugins/output.py
@@ -21,7 +21,7 @@
 About OutFormatPlugins
 
 An OutFormatPlugin is used to format the output of the commands that extract
-information from the perfixes, like status.
+information from the prefixes, like status.
 """
 
 import collections

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -469,6 +469,7 @@ def in_prefix(prefix_class, workdir_class):
                     workdir_path = 'auto'
 
                 workdir_path = workdir_class.resolve_workdir_path(workdir_path)
+                kwargs['workdir_path'] = workdir_path
                 workdir = workdir_class(path=workdir_path)
                 kwargs['parent_workdir'] = workdir
                 if kwargs.get('all_envs', False):

--- a/lago/workdir.py
+++ b/lago/workdir.py
@@ -80,7 +80,7 @@ class Workdir(object):
 
     Properties:
         path(str): Path to the workdir
-        perfixes(dict of str->self.prefix_class): dict with the prefixes in
+        prefixes(dict of str->self.prefix_class): dict with the prefixes in
         the workdir, by name
         current(str): Name of the current prefix
         prefix_class(type): Class to use when creating prefixes


### PR DESCRIPTION
```
lago-demo.git$ lago list envs
current session does not belong to lago group.
Error occured, aborting
Traceback (most recent call last):
  File "lago/lago/cmd.py", line 691, in main
    cli_plugins[args.verb].do_run(args)
  File "lago/lago/plugins/cli.py", line 180, in do_run
    self._do_run(**vars(args))
  File "lago/lago/utils.py", line 488, in wrapper
    return func(*args, **kwargs)
  File "lago/lago/utils.py", line 499, in wrapper
    return func(*args, prefix=prefix, **kwargs)
  File "lago/lago/cmd.py", line 469, in do_list
    workdir.load()
  File "lago/lago/workdir.py", line 157, in load
    basepath, dirs, _ = os.walk(self.path).next()
  File ".venv/lago/lib/python2.7/os.py", line 278, in walk
    names = listdir(top)
TypeError: coercing to Unicode: need string or buffer, NoneType found
```
