### PR TITLE
restore meaningfull README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,12 @@
-docs/index.rst
+The Lago Project
+-----------------
+Lago is an add-hoc virtual framework which helps you build virtualized
+environments on your server or laptop for various use cases.
+
+It currently utilizes 'libvirt' for creating VMs, but we are working on adding
+more providers such as 'containers'.
+
+TODO: Add the 'Lago story' and introduction.
+
+For more info on the Lago project, please visit the full documentation
+page at http://lago.readthedocs.io

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,1 +1,1 @@
-index.rst
+../README.rst


### PR DESCRIPTION
	Before the README file contained all the info
	from the docs, but since we broke up the docs
	into smaller sections, it is now pointing to
	an index file without any info.
	Adding initial content now which should be
	extended in the future to include more info
	on the project, and also link to readthedocs.

Signed-off-by: Eyal Edri <eedri@redhat.com>