### PR TITLE
Continue testing on test failures.

### DIFF
--- a/ovirtlago/__init__.py
+++ b/ovirtlago/__init__.py
@@ -329,7 +329,7 @@ class OvirtPrefix(Prefix):
                 env=env,
                 plugins=nose.core.DefaultPluginManager(),
                 stream=DummyStream(),
-                stopOnError=True,
+                stopOnError=False,
             )
             addplugins = [
                 testlib.TaskLogNosePlugin(),


### PR DESCRIPTION
The fact that a test fail should not stop the tests.
There is value in getting additional coverage, for two reasons:
1. You can find more regressions.
2. If the failure is unrelated to your patch, it gives more assurance in your patch.

Tested with a failure in DirectLUN test - the other tests continue well.

```
@ Run test: 004_basic_sanity.py: 
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
  # add_event: 
  # add_event: Success (in 0:00:00)
  # add_vm_blank: 
  # add_vm_blank: Success (in 0:00:00)
  # add_nic: 
  # add_nic: Success (in 0:00:00)
  # add_disk: 
  # add_disk: Success (in 0:00:19)
  # add_console: 
  # add_console: Success (in 0:00:00)
  # snapshot_merge: 
  # snapshot_merge: Success (in 0:00:44)
  # add_vm_template: 
  # add_vm_template: Success (in 0:00:20)
  # add_directlun: 
    * Collect artifacts: 
    * Collect artifacts: ERROR (in 0:00:03)
  # add_directlun: ERROR (in 0:00:04)
  # vm_run: 
  # vm_run: Success (in 0:00:00)
  # template_export: 
  # template_export: Success (in 0:00:00)
  # vm_migrate: 
  # vm_migrate: Success (in 0:00:00)
  # snapshot_live_merge: 
  # snapshot_live_merge: Success (in 0:00:00)
  # hotplug_nic: 
  # hotplug_nic: Success (in 0:00:00)
  # hotplug_disk: 
  # hotplug_disk: Success (in 0:00:00)
  # Results located at /home/ykaul/ovirt-system-tests/deployment-basic_suite_master/default/nosetests-004_basic_sanity.py.xml
@ Run test: 004_basic_sanity.py: ERROR (in 0:01:30)
```