### PR TITLE
Add possibility of using custom VM XML

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -1182,6 +1182,14 @@ class Prefix(object):
             for host_name, host_spec in domains.iteritems():
                 host_metadata = host_spec.get('metadata', {})
                 deploy_scripts = self._get_scripts(host_metadata)
+                if host_metadata.get('custom-xml', None):
+                    host_metadata['custom-xml'] = os.path.expanduser(
+                        os.path.expandvars(
+                            self._copy_deploy_scripts(
+                                [host_metadata['custom-xml']]
+                            )[0]
+                        )
+                    )
                 new_scripts = self._copy_deploy_scripts(deploy_scripts)
                 self._set_scripts(
                     host_metadata=host_metadata,

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -1182,7 +1182,7 @@ class Prefix(object):
             for host_name, host_spec in domains.iteritems():
                 host_metadata = host_spec.get('metadata', {})
                 deploy_scripts = self._get_scripts(host_metadata)
-                new_scripts = self._copy_delpoy_scripts(deploy_scripts)
+                new_scripts = self._copy_deploy_scripts(deploy_scripts)
                 self._set_scripts(
                     host_metadata=host_metadata,
                     scripts=new_scripts,
@@ -1190,7 +1190,7 @@ class Prefix(object):
 
         return domains
 
-    def _copy_delpoy_scripts(self, scripts):
+    def _copy_deploy_scripts(self, scripts):
         """
         Copy the given deploy scripts to the scripts dir in the prefix
 

--- a/lago/vm.py
+++ b/lago/vm.py
@@ -223,8 +223,13 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
         return self.vm.virt_env.prefixed_name(self.vm.name())
 
     def _libvirt_xml(self):
-        with open(_path_to_xml('dom_template.xml')) as xml_fd:
-            dom_raw_xml = xml_fd.read()
+        metadata = self.vm.metadata
+        if metadata and 'custom-xml' in metadata:
+            with open(metadata['custom-xml']) as xml_fd:
+                dom_raw_xml = xml_fd.read()
+        else:
+            with open(_path_to_xml('dom_template.xml')) as xml_fd:
+                dom_raw_xml = xml_fd.read()
 
         capabilities_raw_xml = self.libvirt_con.getCapabilities()
         capabilities_xml = lxml.etree.fromstring(capabilities_raw_xml)
@@ -255,8 +260,7 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
             dom_raw_xml = dom_raw_xml.replace(key, str(val), 1)
 
         dom_xml = lxml.etree.fromstring(dom_raw_xml)
-        self._compat_libvirt_devices(
-            dom_xml.xpath('/domain/devices')[0])
+        self._compat_libvirt_devices(dom_xml.xpath('/domain/devices')[0])
 
         return lxml.etree.tostring(dom_xml)
 


### PR DESCRIPTION
Lago only has a single libvirt XML in it's code base. This approach is limiting for testing of more complex features such as device assignment. We therefore allow users to specify custom libvirt XML while keeping lago-specific replacements available.
