### PR TITLE
Update fedora>23 to use python2-pbr

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -41,7 +41,6 @@ install -d %{buildroot}/var/lib/lago/reposync
 Summary: Library to perform lago operations
 BuildArch: noarch
 BuildRequires: python2-devel
-BuildRequires: python-pbr
 BuildRequires: python-stevedore
 BuildRequires: python-setuptools
 BuildRequires: python-magic
@@ -61,7 +60,9 @@ BuildRequires: python-configparser
 
 %if 0%{?fedora} >= 23
 BuildRequires: python2-dulwich
+BuildRequires: python2-pbr
 %else
+BuildRequires: python-pbr
 BuildRequires: python-dulwich
 %endif
 BuildRequires: python-flake8


### PR DESCRIPTION
closes: https://github.com/lago-project/lago/issues/173
Signed-off-by: Nadav Goldin <ngoldin@redhat.com>