### PR TITLE
Allow using lago on systems which runs setevedore 1.1.0

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -614,11 +614,23 @@ def create_parser(cli_plugins, out_plugins):
         type=int,
         help='How many task levels to show'
     )
-    pkg_info = pkg_resources.require("lago")[0]
+
+    try:
+        # Checks that all the deps are installed
+        pkg_resources.require("lago")[0]
+    except pkg_resources.VersionConflict as e:
+        # Hack that allows to run stevedore without checking
+        # for it's dep. it is required for systems running stevedore 1.1.0
+        # and pbr > 1.
+        LOGGER.debug(e.message)
+        pkgs = e[2]
+        if len(pkgs) > 1 or 'stevedore' not in pkgs:
+            raise e
+
     parser.add_argument(
         '--version',
         action='version',
-        version='%(prog)s ' + pkg_info.version,
+        version='%(prog)s ' + pkg_resources.get_distribution("lago").version,
     )
     parser.add_argument(
         '--out-format',


### PR DESCRIPTION
1. On some versions of rhel pbr 1.10.0 and stevedore 1.1.0
are the only versions availble. While stevedore 1.1.0
require pbr<1, it can also work with pbr 1.10.0 (tested
on my system). Added an exception handling in order to
bypass the requirements.

2. Changed the way we check for lago's version to suit
the change in [1].

example of the error:

```
traceback (most recent call last):
  File "/usr/bin/lago", line 10, in <module>
    sys.exit(main())
  File "/usr/lib/python2.7/site-packages/lago/cmd.py", line 659, in main
    parser = create_parser(cli_plugins=cli_plugins, out_plugins=out_plugins)
  File "/usr/lib/python2.7/site-packages/lago/cmd.py", line 598, in create_parser
    pkg_info = pkg_resources.require("lago")[0]
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 943, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 834, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (pbr 1.8.2.dev31 (/usr/lib/python2.7/site-packages), Requirement.parse('pbr!=0.7,<1.0,>=0.6'), set(['stevedore']))
```
