### PR TITLE
Fix HEHostVM:_artifact_paths

### DIFF
--- a/ovirtlago/virt.py
+++ b/ovirtlago/virt.py
@@ -249,9 +249,7 @@ class HostVM(lago.vm.DefaultVM):
 class HEHostVM(HostVM):
     def _artifact_paths(self):
         inherited_artifacts = super(HEHostVM, self)._artifact_paths()
-        return set(
-            inherited_artifacts + [
-                '/var/log/ovirt-hosted-engine-setup',
-                '/var/log/ovirt-hosted-engine-ha',
-            ]
-        )
+        return inherited_artifacts | set((
+            '/var/log/ovirt-hosted-engine-setup',
+            '/var/log/ovirt-hosted-engine-ha',
+        ))


### PR DESCRIPTION
It tried to call '+' on a set (which it received from its parent) and a
list. Use set join for now.

_artifact_paths should probably make up its mind about what it should
return. In some places it returns a list and others a set.

Change-Id: Ia0d4a438133c8cae2980cca96e52755177269db1
Signed-off-by: Yedidyah Bar David <didi@redhat.com>