### PR TITLE
Add 'generate-config' verb to functional tests list

### DIFF
--- a/tests/functional/common.bash
+++ b/tests/functional/common.bash
@@ -16,6 +16,7 @@ VERBS=(
     stop
     template-repo
     console
+    generate-config
 )
 FIXTURES="$BATS_TEST_DIRNAME/fixtures"
 


### PR DESCRIPTION
ATM, only thing it tests is if it outputs the help.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>