### PR TITLE
Switch to optional freeze the FS before logs extraction.

### DIFF
--- a/lago/vm.py
+++ b/lago/vm.py
@@ -408,14 +408,16 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
             self._reclaim_disks()
             self.vm._spec['snapshots'][name] = snap_info
 
-    def _extract_paths_live(self, paths):
-        self.vm.guest_agent().start()
-        dom = self.libvirt_con.lookupByName(self._libvirt_name())
-        dom.fsFreeze()
+    def _extract_paths_live(self, paths, freeze=False):
+        if freeze:
+            dom = self.libvirt_con.lookupByName(self._libvirt_name())
+            self.vm.guest_agent().start()
+            dom.fsFreeze()
         try:
             self._extract_paths_dead(paths=paths)
         finally:
-            dom.fsThaw()
+            if freeze:
+                dom.fsThaw()
 
     def _extract_paths_dead(self, paths):
         disk_path = os.path.expandvars(self.vm._spec['disks'][0]['path'])


### PR DESCRIPTION
More importantly, by default, the call will not freeze the FS.
There is no reason to do it, for two reasons:
1. We open the FS in read-only - so no corruption can happen.
2. The system is quite stable - we already passed whatever
test we passed or failed - all logs are in the system already
(especially as in ovirt-system-tests we complete the suite after
failure)

This may prevent issues when the hosts are disconnected due to a
long freeze