### PR TITLE
Bump yapf version 0.7.1 -> 0.14.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,6 @@ The Lago Project
 Lago is an add-hoc virtual framework which helps you build virtualized
 environments on your server or laptop for various use cases.
 
-It currently utilizes 'libvirt' for creating VMs, but we are working on adding
-more providers such as 'containers'.
+For the official docs see: http://lago.readthedocs.io
 
-TODO: Add the 'Lago story' and introduction.
-
-For more info on the Lago project, please visit the full documentation
-page at http://lago.readthedocs.io
+.. todo:: Add the 'Lago story' and introduction.

--- a/docs/Debugging_and_Troubleshooting.rst
+++ b/docs/Debugging_and_Troubleshooting.rst
@@ -81,7 +81,7 @@ the full command line.
 **NOTE**: You can use any other template repo if you specify your own json file
 there
 
-**TODO**: document the repo store json file format
+.. todo:: document the repo store json file format
 
 
 Initializing the prefix

--- a/docs/Jenkins_Example.rst
+++ b/docs/Jenkins_Example.rst
@@ -44,6 +44,7 @@ From within the cloned repository, run the following commands:
     lago start
 
 -   Installing the vms:
+
    -  Jenkins will be installed on the server.
    -  OpenJDK will be installed on the slaves.
 
@@ -81,8 +82,6 @@ When you done with the enviroment:
 Note:
  To turn on the vms, use::
 
-::
-
     lago start
 
 And if you will not have a need for the environment in the future:
@@ -97,4 +96,4 @@ And if you will not have a need for the environment in the future:
 If this simple example just got you even more interested, join the major leauge and try out the
 oVirt example! oVirt_Example_
 
-.. _oVirt_Example: oVirt_Example.html 
+.. _oVirt_Example: oVirt_Example.html

--- a/docs/Lago_Examples.rst
+++ b/docs/Lago_Examples.rst
@@ -1,5 +1,5 @@
 Getting started with some Lago Examples!
-=======================================
+=========================================
 
 Get Lago up & running in no time using one of the available examples
 
@@ -9,7 +9,7 @@ Available Examples
 ------------------
 
 * Simple Jenkins server + slaves: Jenkins_Example_
-* Advanced oVirt example (using nested virtualization): oVirt_Example_ 
+* Advanced oVirt example (using nested virtualization): oVirt_Example_
 
 .. _Jenkins_Example: Jenkins_Example.html
 .. _oVirt_Example: oVirt_Example.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,11 @@ subprocess.call(
         os.path.dirname(__file__), '../lago_template_repo'
     ]
 )
-subprocess.call(['make', '--directory=..', 'changelog', ])
+subprocess.call([
+    'make',
+    '--directory=..',
+    'changelog',
+])
 shutil.move('../ChangeLog', '_static/ChangeLog.txt')
 
 # Mock all the modules that are included by lago, so autoimport works as
@@ -226,12 +230,13 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-    '**': [
-        'about.html',
-        'navigation.html',
-        'relations.html',
-        'searchbox.html',
-    ],
+    '**':
+        [
+            'about.html',
+            'navigation.html',
+            'relations.html',
+            'searchbox.html',
+        ],
 }
 
 # Additional templates that should be rendered to pages, maps page names to
@@ -301,9 +306,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (
-        master_doc, 'Lago.tex', u'Lago Documentation', u'David Caro', 'manual'
-    )
+    (master_doc, 'Lago.tex', u'Lago Documentation', u'David Caro', 'manual')
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ environments on your server or laptop for various use cases.
 It currently utilizes 'libvirt' for creating VMs, but we are working on adding
 more providers such as 'containers'.
 
-TODO: Add the 'Lago story' and introduction.
+.. todo:: Add the 'Lago story' and introduction.
 
 Getting started
 ---------------

--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -33,7 +33,10 @@ import lago.plugins
 import lago.plugins.cli
 import lago.templates
 from lago.config import config
-from lago import (log_utils, workdir as lago_workdir, )
+from lago import (
+    log_utils,
+    workdir as lago_workdir,
+)
 from lago.utils import (in_prefix, with_logging)
 
 LOGGER = logging.getLogger('cli')
@@ -130,9 +133,8 @@ def do_init(
     if virt_config is None:
         virt_config = os.path.abspath('LagoInitFile')
 
-    os.environ['LAGO_INITFILE_PATH'] = os.path.dirname(
-        os.path.abspath(virt_config)
-    )
+    os.environ['LAGO_INITFILE_PATH'
+               ] = os.path.dirname(os.path.abspath(virt_config))
 
     if prefix_name == 'current':
         prefix_name = 'default'
@@ -339,10 +341,8 @@ def do_shell(prefix, host, args=None, **kwargs):
     except KeyError:
         LOGGER.error('Unable to find VM %s', host)
         LOGGER.info(
-            'Available VMs:\n\t' + '\n\t'.join(
-                prefix.virt_env.get_vms().keys(
-                )
-            )
+            'Available VMs:\n\t' +
+            '\n\t'.join(prefix.virt_env.get_vms().keys())
         )
         raise
 
@@ -380,10 +380,8 @@ def do_console(prefix, host, **kwargs):
     except KeyError:
         LOGGER.error('Unable to find VM %s', host)
         LOGGER.info(
-            'Available VMs:\n\t' + '\n\t'.join(
-                prefix.virt_env.get_vms().keys(
-                )
-            )
+            'Available VMs:\n\t' +
+            '\n\t'.join(prefix.virt_env.get_vms().keys())
         )
         raise
 
@@ -402,44 +400,51 @@ def do_status(prefix, out_format, **kwargs):
         uuid = f.read()
 
     info_dict = {
-        'Prefix': {
-            'Base directory': prefix.paths.prefix,
-            'UUID': uuid,
-            'Networks': dict(
-                (
-                    net.name(),
-                    {
-                        'gateway': net.gw(),
-                        'status': net.alive() and 'up' or 'down',
-                        'management': net.is_management(),
-                    }
-                ) for net in prefix.virt_env.get_nets().values()
-            ),
-            'VMs': dict(
-                (
-                    vm.name(),
-                    {
-                        'distro': vm.distro(),
-                        'root password': vm.root_password(),
-                        'status': vm.state(),
-                        'snapshots': ', '.join(vm._spec['snapshots'].keys()),
-                        'VNC port': vm.vnc_port() if vm.alive() else None,
-                        'metadata': vm.metadata,
-                        'NICs': dict(
-                            (
-                                'eth%d' % i,
-                                {
-                                    'network': nic['net'],
-                                    'ip': nic.get('ip', 'N/A'),
-                                }
-
-                            ) for i, nic in enumerate(vm.nics())
-                        ),
-                    }
-
-                ) for vm in prefix.virt_env.get_vms().values()
-            ),
-        },
+        'Prefix':
+            {
+                'Base directory':
+                    prefix.paths.prefix,
+                'UUID':
+                    uuid,
+                'Networks':
+                    dict(
+                        (
+                            net.name(), {
+                                'gateway': net.gw(),
+                                'status': net.alive() and 'up' or 'down',
+                                'management': net.is_management(),
+                            }
+                        ) for net in prefix.virt_env.get_nets().values()
+                    ),
+                'VMs':
+                    dict(
+                        (
+                            vm.name(), {
+                                'distro':
+                                    vm.distro(),
+                                'root password':
+                                    vm.root_password(),
+                                'status':
+                                    vm.state(),
+                                'snapshots':
+                                    ', '.join(vm._spec['snapshots'].keys()),
+                                'VNC port':
+                                    vm.vnc_port() if vm.alive() else None,
+                                'metadata':
+                                    vm.metadata,
+                                'NICs':
+                                    dict(
+                                        (
+                                            'eth%d' % i, {
+                                                'network': nic['net'],
+                                                'ip': nic.get('ip', 'N/A'),
+                                            }
+                                        ) for i, nic in enumerate(vm.nics())
+                                    ),
+                            }
+                        ) for vm in prefix.virt_env.get_vms().values()
+                    ),
+            },
     }
 
     print out_format.format(info_dict)
@@ -499,10 +504,8 @@ def do_copy_from_vm(prefix, host, remote_path, local_path, **kwargs):
     except KeyError:
         LOGGER.error('Unable to find VM %s', host)
         LOGGER.info(
-            'Available VMs:\n\t' + '\n\t'.join(
-                prefix.virt_env.get_vms().keys(
-                )
-            )
+            'Available VMs:\n\t' +
+            '\n\t'.join(prefix.virt_env.get_vms().keys())
         )
         raise
 
@@ -541,10 +544,8 @@ def do_copy_to_vm(prefix, host, remote_path, local_path, **kwargs):
     except KeyError:
         LOGGER.error('Unable to find VM %s', host)
         LOGGER.info(
-            'Available VMs:\n\t' + '\n\t'.join(
-                prefix.virt_env.get_vms().keys(
-                )
-            )
+            'Available VMs:\n\t' +
+            '\n\t'.join(prefix.virt_env.get_vms().keys())
         )
         raise
 
@@ -609,10 +610,7 @@ def create_parser(cli_plugins, out_plugins):
         help='Log level to use'
     )
     parser.add_argument(
-        '--logdepth',
-        default=3,
-        type=int,
-        help='How many task levels to show'
+        '--logdepth', default=3, type=int, help='How many task levels to show'
     )
 
     try:
@@ -774,7 +772,10 @@ def main():
     out_plugins = lago.plugins.load_plugins(
         lago.plugins.PLUGIN_ENTRY_POINTS['out']
     )
-    parser = create_parser(cli_plugins=cli_plugins, out_plugins=out_plugins, )
+    parser = create_parser(
+        cli_plugins=cli_plugins,
+        out_plugins=out_plugins,
+    )
     args = parser.parse_args()
     config.update_args(args)
 

--- a/lago/config.py
+++ b/lago/config.py
@@ -42,9 +42,7 @@ def _get_configs_path():
 
     paths = []
     xdg_paths = [
-        path for path in base_dirs.load_config_paths(
-            'lago', 'lago.conf'
-        )
+        path for path in base_dirs.load_config_paths('lago', 'lago.conf')
     ]
     paths.extend([path for path in CONFS_PATH if os.path.exists(path)])
     paths.extend(reversed(xdg_paths))
@@ -54,10 +52,10 @@ def _get_configs_path():
 def get_env_dict(root_section):
     """Read all Lago variables from the environment.
     The lookup format is:
-      LAGO_VARNAME - will land into 'lago' section
-      LAGO__SECTION1__VARNAME - will land into 'section1' section, notice
-      the double '__'.
-      LAGO__LONG_SECTION_NAME__VARNAME - will land into 'long_section_name'
+    LAGO_VARNAME - will land into 'lago' section
+    LAGO__SECTION1__VARNAME - will land into 'section1' section, notice
+    the double '__'.
+    LAGO__LONG_SECTION_NAME__VARNAME - will land into 'long_section_name'
 
 
     Returns:
@@ -122,9 +120,9 @@ class ConfigLoad(object):
     def load(self):
         """Load all configuration from INI format files and ENV, always
         preferring the last read. Order of loading is:
-          1) Custom paths as defined in constants.CONFS_PATH
-          2) XDG standard paths
-          3) Environment variables
+        1) Custom paths as defined in constants.CONFS_PATH
+        2) XDG standard paths
+        3) Environment variables
 
         Returns:
             dict: dict of section configuration dicts
@@ -169,10 +167,8 @@ class ConfigLoad(object):
         configp.read_dict(self._config)
         configp.read_string(ini_str)
         self._config.update(
-            {
-                s: dict(configp.items(s))
-                for s in configp.sections()
-            }
+            {s: dict(configp.items(s))
+             for s in configp.sections()}
         )
 
     def get(self, *args):

--- a/lago/log_utils.py
+++ b/lago/log_utils.py
@@ -27,7 +27,10 @@ import re
 import sys
 import datetime
 import threading
-from collections import (OrderedDict, deque, )
+from collections import (
+    OrderedDict,
+    deque,
+)
 from functools import wraps
 
 #: Message to be shown when a task is started
@@ -439,7 +442,10 @@ class TaskHandler(logging.StreamHandler):
             return
 
         # All the parents inherit the failure
-        self.mark_parent_tasks_as_failed(self.cur_task, flush_logs=True, )
+        self.mark_parent_tasks_as_failed(
+            self.cur_task,
+            flush_logs=True,
+        )
 
         # Show the start headers for all the parent tasks if they were not
         # shown by the depth level limit
@@ -501,9 +507,9 @@ class TaskHandler(logging.StreamHandler):
 
         if is_header:
             extra_prefix = (
-                self.get_task_indicator(task_level - 1) + ' ' + (
-                    '' if self.am_i_main_thread else '[%s] ' % self.cur_thread
-                ) + task + ': '
+                self.get_task_indicator(task_level - 1) + ' ' +
+                ('' if self.am_i_main_thread else '[%s] ' % self.cur_thread) +
+                task + ': '
             )
             record.levelno = logging.INFO
         else:

--- a/lago/plugins/__init__.py
+++ b/lago/plugins/__init__.py
@@ -64,9 +64,8 @@ def load_plugins(namespace, instantiate=True):
     mgr = ExtensionManager(
         namespace=namespace,
         on_load_failure_callback=(
-            lambda _, ep, err: LOGGER.debug(
-                'Could not load %r: %s', ep.name, err
-            )
+            lambda _, ep, err: LOGGER.
+            debug('Could not load %r: %s', ep.name, err)
         )
     )
     if instantiate:

--- a/lago/plugins/cli.py
+++ b/lago/plugins/cli.py
@@ -95,7 +95,11 @@ TODO: Allow per-plugin namespacing to get rid of the `**kwargs` parameter
 """
 
 import functools
-from abc import (abstractmethod, abstractproperty, ABCMeta, )
+from abc import (
+    abstractmethod,
+    abstractproperty,
+    ABCMeta,
+)
 
 from . import Plugin
 

--- a/lago/plugins/output.py
+++ b/lago/plugins/output.py
@@ -95,7 +95,11 @@ class DefaultOutFormatPlugin(OutFormatPlugin):
 
 class JSONOutFormatPlugin(OutFormatPlugin):
     def format(self, info_dict):
-        return json.dumps(info_dict, sort_keys=True, indent=4, )
+        return json.dumps(
+            info_dict,
+            sort_keys=True,
+            indent=4,
+        )
 
 
 class YAMLOutFormatPlugin(OutFormatPlugin):

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -21,7 +21,7 @@
 VM Plugins
 ============
 There are two VM-related plugin extension points, there's the
-`VM Type Plugin`_, that allows you to modify at a higher level the inner
+VM Type Plugin, that allows you to modify at a higher level the inner
 workings of the VM class (domain concept in the initfile).
 The other plugin extension point, the [VM Provider Plugin], that allows you to
 create an alternative implementation of the provisioning details for the VM,
@@ -36,7 +36,12 @@ from abc import (ABCMeta, abstractmethod)
 
 from scp import SCPClient
 
-from .. import (utils, log_utils, plugins, ssh, )
+from .. import (
+    utils,
+    log_utils,
+    plugins,
+    ssh,
+)
 from lago.config import config
 
 LOGGER = logging.getLogger(__name__)

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -362,8 +362,7 @@ class Prefix(object):
 
                 if nic['ip'] in net['mapping'].values():
                     conflict_list = [
-                        name
-                        for name, ip in net['mapping'].items()
+                        name for name, ip in net['mapping'].items()
                         if ip == net['ip']
                     ]
                     raise RuntimeError(
@@ -398,12 +397,9 @@ class Prefix(object):
 
                 allocated = net['mapping'].values()
                 vacant = _create_ip(
-                    net['gw'], set(range(2, 255)).difference(
-                        set(
-                            [
-                                int(ip.split('.')[-1]) for ip in allocated
-                            ]
-                        )
+                    net['gw'],
+                    set(range(2, 255)).difference(
+                        set([int(ip.split('.')[-1]) for ip in allocated])
                     ).pop()
                 )
                 nic['ip'] = vacant
@@ -513,7 +509,11 @@ class Prefix(object):
 
     @staticmethod
     def _generate_disk_name(host_name, disk_name, disk_format):
-        return '%s_%s.%s' % (host_name, disk_name, disk_format, )
+        return '%s_%s.%s' % (
+            host_name,
+            disk_name,
+            disk_format,
+        )
 
     def _generate_disk_path(self, disk_name):
         return os.path.expandvars(self.paths.images(disk_name))
@@ -635,17 +635,14 @@ class Prefix(object):
         )
         if template_version not in template_store:
             LOGGER.info(
-                log_utils.log_always(
-                    "Template %s not in cache, downloading"
-                ) % template_version.name,
+                log_utils.log_always("Template %s not in cache, downloading") %
+                template_version.name,
             )
             template_store.download(template_version)
 
         template_store.mark_used(template_version, self.paths.uuid())
         disk_metadata.update(
-            template_store.get_stored_metadata(
-                template_version,
-            ),
+            template_store.get_stored_metadata(template_version, ),
         )
         base = template_store.get_path(template_version)
         qemu_cmd = ['qemu-img', 'create', '-f', 'qcow2', '-b', base, disk_path]
@@ -685,9 +682,7 @@ class Prefix(object):
         if not os.path.exists(ova_extracted_dir):
             os.makedirs(ova_extracted_dir)
             subprocess.check_output(
-                [
-                    "tar", "-xvf", filename, "-C", ova_extracted_dir
-                ],
+                ["tar", "-xvf", filename, "-C", ova_extracted_dir],
                 stderr=subprocess.STDOUT
             )
 
@@ -738,15 +733,17 @@ class Prefix(object):
 
         if image_file is not None:
             disk_meta = {"root-partition": "/dev/sda1"}
-            disk_spec = [{"type": "template",
-                          "template_type": "qcow2",
-                          "format": "qcow2",
-                          "dev": "vda",
-                          "name": "root",
-                          "name": os.path.basename(image_file),
-                          "path": ova_extracted_dir +
-                                 "/images/" + image_file,
-                          "metadata": disk_meta}]
+            disk_spec = [
+                {
+                    "type": "template",
+                    "template_type": "qcow2",
+                    "format": "qcow2",
+                    "dev": "vda",
+                    "name": os.path.basename(image_file),
+                    "path": ova_extracted_dir + "/images/" + image_file,
+                    "metadata": disk_meta
+                }
+            ]
 
         return disk_spec, memory, vcpus
 
@@ -898,11 +895,7 @@ class Prefix(object):
         return new_disks
 
     def virt_conf(
-        self,
-        conf,
-        template_repo=None,
-        template_store=None,
-        do_bootstrap=True
+        self, conf, template_repo=None, template_store=None, do_bootstrap=True
     ):
         """
         Initializes all the virt infrastructure of the prefix, creating the
@@ -920,9 +913,7 @@ class Prefix(object):
         os.environ['LAGO_PREFIX_PATH'] = self.paths.prefix
         with utils.RollbackContext() as rollback:
             rollback.prependDefer(
-                shutil.rmtree,
-                self.paths.prefix,
-                ignore_errors=True
+                shutil.rmtree, self.paths.prefix, ignore_errors=True
             )
             conf = self._prepare_domains_images(
                 conf=conf,

--- a/lago/service.py
+++ b/lago/service.py
@@ -17,7 +17,10 @@
 #
 # Refer to the README and COPYING files for full details of the license
 #
-from lago.plugins.service import (ServicePlugin, ServiceState, )
+from lago.plugins.service import (
+    ServicePlugin,
+    ServiceState,
+)
 
 
 class SystemdService(ServicePlugin):

--- a/lago/ssh.py
+++ b/lago/ssh.py
@@ -12,7 +12,10 @@ import logging
 
 import paramiko
 
-from . import (utils, log_utils, )
+from . import (
+    utils,
+    log_utils,
+)
 from .config import config
 
 LOGGER = logging.getLogger(__name__)
@@ -61,12 +64,10 @@ def ssh(
 
     channel.shutdown_write()
     return_code, out, err = drain_ssh_channel(
-        channel, **(
-            show_output and {} or {
-                'stdout': None,
-                'stderr': None
-            }
-        )
+        channel, **(show_output and {} or {
+            'stdout': None,
+            'stderr': None
+        })
     )
 
     channel.close()
@@ -100,7 +101,7 @@ def ssh(
 def wait_for_ssh(
     ip_addr,
     host_name=None,
-    connect_timeout=600,    # 10 minutes
+    connect_timeout=600,  # 10 minutes
     ssh_key=None,
     username='root',
     password='123456',
@@ -238,7 +239,12 @@ def drain_ssh_channel(chan, stdin=None, stdout=sys.stdout, stderr=sys.stderr):
         if stderr and err_queue:
             write_streams.append(stderr)
 
-        read, write, _ = select.select(read_streams, write_streams, [], 0.1, )
+        read, write, _ = select.select(
+            read_streams,
+            write_streams,
+            [],
+            0.1,
+        )
 
         if stdin in read:
             chunk = utils.read_nonblocking(stdin)
@@ -323,7 +329,11 @@ def get_ssh_client(
 
         start_time = time.time()
         while ssh_tries > 0:
-            LOGGER.debug('Still got %d tries for %s', ssh_tries, host_name, )
+            LOGGER.debug(
+                'Still got %d tries for %s',
+                ssh_tries,
+                host_name,
+            )
             client = paramiko.SSHClient()
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy(), )
             try:

--- a/lago/sysprep.py
+++ b/lago/sysprep.py
@@ -62,9 +62,7 @@ def add_ssh_key(key, with_restorecon_fix=False):
         _DOT_SSH,
         '--chmod',
         '0700:%s' % _DOT_SSH,
-    ) + _upload_file(
-        _AUTHORIZED_KEYS, key
-    )
+    ) + _upload_file(_AUTHORIZED_KEYS, key)
     if (not os.stat(key).st_uid == 0 or not os.stat(key).st_gid == 0):
         extra_options += (
             '--run-command',
@@ -73,7 +71,10 @@ def add_ssh_key(key, with_restorecon_fix=False):
     if with_restorecon_fix:
         # Fix for fc23 not relabeling on boot
         # https://bugzilla.redhat.com/1049656
-        extra_options += ('--firstboot-command', 'restorecon -R /root/.ssh', )
+        extra_options += (
+            '--firstboot-command',
+            'restorecon -R /root/.ssh',
+        )
     return extra_options
 
 
@@ -85,10 +86,8 @@ def set_selinux_mode(mode):
         '0755:%s' % _SELINUX_CONF_DIR,
     ) + _write_file(
         _SELINUX_CONF_PATH,
-        (
-            'SELINUX=%s\n'
-            'SELINUXTYPE=targeted\n'
-        ) % mode,
+        ('SELINUX=%s\n'
+         'SELINUXTYPE=targeted\n') % mode,
     )
 
 

--- a/lago/templates.py
+++ b/lago/templates.py
@@ -172,9 +172,8 @@ class HttpTemplateProvider:
         def report(count, block_size, total_size):
             percent = (count * block_size * 100 / float(total_size))
             sys.stdout.write(
-                "\r% 3.1f%%" % percent + " complete (%d " % (
-                    count * block_size / 1024
-                ) + "Kilobytes)"
+                "\r% 3.1f%%" % percent + " complete (%d " %
+                (count * block_size / 1024) + "Kilobytes)"
             )
             sys.stdout.flush()
 
@@ -260,6 +259,7 @@ class HttpTemplateProvider:
         finally:
             response.close()
 
+
 #: Registry for template providers
 _PROVIDERS = {
     'file': FileSystemTemplateProvider,
@@ -286,11 +286,16 @@ def find_repo_by_name(name, repo_dir=None):
     if repo_dir is None:
         repo_dir = config.get('template_repos')
 
-    ret, out, _ = utils.run_command(['find', repo_dir, '-name', '*.json', ], )
+    ret, out, _ = utils.run_command([
+        'find',
+        repo_dir,
+        '-name',
+        '*.json',
+    ], )
 
     repos = [
-        TemplateRepository.from_url(line.strip())
-        for line in out.split('\n') if len(line.strip())
+        TemplateRepository.from_url(line.strip()) for line in out.split('\n')
+        if len(line.strip())
     ]
 
     for repo in repos:

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -155,9 +155,8 @@ def _run_command(
         env['PATH'] = ':'.join(
             list(
                 set(
-                    env.get('PATH', '').split(':') + os.environ[
-                        'PATH'
-                    ].split(':')
+                    env.get('PATH', '').split(':') + os.environ['PATH']
+                    .split(':')
                 ),
             ),
         )
@@ -504,9 +503,8 @@ def with_logging(func):
 
 
 def add_timestamp_suffix(base_string):
-    return datetime.datetime.fromtimestamp(
-        time.time()
-    ).strftime(base_string + '.%Y-%m-%d_%H:%M:%S')
+    return datetime.datetime.fromtimestamp(time.time(
+    )).strftime(base_string + '.%Y-%m-%d_%H:%M:%S')
 
 
 def rotate_dir(base_dir):
@@ -522,14 +520,12 @@ def ipv4_to_mac(ip):
 
 def argparse_to_ini(parser, root_section='lago', incl_unset=False):
     subparsers_actions = [
-        action
-        for action in parser._actions
+        action for action in parser._actions
         if isinstance(action, argparse._SubParsersAction)
     ]
 
     root_actions = [
-        action
-        for action in parser._actions
+        action for action in parser._actions
         if not isinstance(action, argparse._SubParsersAction)
     ]
 
@@ -541,9 +537,7 @@ def argparse_to_ini(parser, root_section='lago', incl_unset=False):
             _add_subparser_to_cp(cp, choice, subparser._actions, incl_unset)
 
     header = '# Lago configuration file, generated: {0}'.format(
-        time.strftime(
-            "%c"
-        )
+        time.strftime("%c")
     )
     with StringIO() as ini_str:
         cp.write(ini_str)
@@ -553,11 +547,9 @@ def argparse_to_ini(parser, root_section='lago', incl_unset=False):
 def _add_subparser_to_cp(cp, section, actions, incl_unset):
     cp.add_section(section)
     print_actions = (
-        action
-        for action in actions
-        if (action.default and action.default != '==SUPPRESS==') or (
-            action.default is None and incl_unset
-        )
+        action for action in actions
+        if (action.default and action.default != '==SUPPRESS=='
+            ) or (action.default is None and incl_unset)
     )
     for action in print_actions:
         var = str(action.dest)

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -26,7 +26,13 @@ import uuid
 
 import lxml.etree
 
-from . import (brctl, utils, log_utils, plugins, libvirt_utils, )
+from . import (
+    brctl,
+    utils,
+    log_utils,
+    plugins,
+    libvirt_utils,
+)
 from .config import config
 LOGGER = logging.getLogger(__name__)
 LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
@@ -50,14 +56,15 @@ def _guestfs_copy_path(g, guest_path, host_path):
                     guest_path,
                     path,
                 ),
-                os.path.join(
-                    host_path, os.path.basename(path)
-                ),
+                os.path.join(host_path, os.path.basename(path)),
             )
 
 
 def _path_to_xml(basename):
-    return os.path.join(os.path.dirname(__file__), basename, )
+    return os.path.join(
+        os.path.dirname(__file__),
+        basename,
+    )
 
 
 class VirtEnv(object):
@@ -112,9 +119,8 @@ class VirtEnv(object):
             vm_type = self.vm_types[vm_type_name]
         except KeyError:
             raise RuntimeError(
-                'Unknown VM type: {0}, available types: {1}'.format(
-                    vm_type_name, ','.join(self.vm_types.keys())
-                )
+                'Unknown VM type: {0}, available types: {1}'.
+                format(vm_type_name, ','.join(self.vm_types.keys()))
             )
         vm_spec['vm-type'] = vm_type_name
         return vm_type(self, vm_spec)
@@ -171,9 +177,7 @@ class VirtEnv(object):
             nets = set()
             for vm in vms:
                 nets = nets.union(
-                    set(
-                        self._nets[net_name] for net_name in vm.nets()
-                    )
+                    set(self._nets[net_name] for net_name in vm.nets())
                 )
 
         with LogTask(log_msg), utils.RollbackContext() as rollback:
@@ -223,8 +227,8 @@ class VirtEnv(object):
         else:
             try:
                 return [
-                    net
-                    for net in self.get_nets().values() if net.is_management()
+                    net for net in self.get_nets().values()
+                    if net.is_management()
                 ].pop()
             except IndexError:
                 return self.get_nets().values().pop()
@@ -264,7 +268,10 @@ class VirtEnv(object):
             for vm in self._vms.values():
                 vm.save()
 
-        spec = {'nets': self._nets.keys(), 'vms': self._vms.keys(), }
+        spec = {
+            'nets': self._nets.keys(),
+            'vms': self._vms.keys(),
+        }
 
         with LogTask('Save env'):
             with open(self.virt_path('env'), 'w') as f:
@@ -353,9 +360,8 @@ class Network(object):
     def stop(self):
         if self.alive():
             with LogTask('Destroy network %s' % self.name()):
-                self.libvirt_con.networkLookupByName(
-                    self._libvirt_name(),
-                ).destroy()
+                self.libvirt_con.networkLookupByName(self._libvirt_name(),
+                                                     ).destroy()
 
     def save(self):
         with open(self._env.virt_path('net-%s' % self.name()), 'w') as f:

--- a/lago/vm.py
+++ b/lago/vm.py
@@ -35,7 +35,10 @@ log_task = functools.partial(log_utils.log_task, logger=LOGGER)
 
 
 def _path_to_xml(basename):
-    return os.path.join(os.path.dirname(__file__), basename, )
+    return os.path.join(
+        os.path.dirname(__file__),
+        basename,
+    )
 
 
 def _check_defined(func):
@@ -124,8 +127,7 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
                         sysprep.config_net_interface_dhcp(
                             'eth%d' % index,
                             utils.ipv4_to_mac(nic['ip']),
-                        )
-                        for index, nic in enumerate(self.vm._spec['nics'])
+                        ) for index, nic in enumerate(self.vm._spec['nics'])
                         if 'ip' in nic
                     ],
                 )
@@ -320,7 +322,10 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
             devices.append(disk)
 
         for dev_spec in self.vm._spec['nics']:
-            interface = lxml.etree.Element('interface', type='network', )
+            interface = lxml.etree.Element(
+                'interface',
+                type='network',
+            )
             interface.append(
                 lxml.etree.Element(
                     'source',
@@ -329,7 +334,12 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
                     ),
                 ),
             )
-            interface.append(lxml.etree.Element('model', type='virtio', ), )
+            interface.append(
+                lxml.etree.Element(
+                    'model',
+                    type='virtio',
+                ),
+            )
             if 'ip' in dev_spec:
                 interface.append(
                     lxml.etree.Element(
@@ -384,16 +394,13 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
                 raise
 
             snap_info = []
-            new_disks = lxml.etree.fromstring(
-                dom.XMLDesc()
-            ).xpath('devices/disk')
+            new_disks = lxml.etree.fromstring(dom.XMLDesc()
+                                              ).xpath('devices/disk')
             for disk, xml_node in zip(self.vm._spec['disks'], new_disks):
                 disk['path'] = xml_node.xpath('source')[0].attrib['file']
                 disk['format'] = 'qcow2'
                 snap_disk = disk.copy()
-                snap_disk['path'] = xml_node.xpath(
-                    'backingStore',
-                )[0].xpath(
+                snap_disk['path'] = xml_node.xpath('backingStore', )[0].xpath(
                     'source',
                 )[0].attrib['file']
                 snap_info.append(snap_disk)
@@ -422,8 +429,7 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
         gfs_cli.set_backend('direct')
         gfs_cli.launch()
         rootfs = [
-            filesystem
-            for filesystem in gfs_cli.list_filesystems()
+            filesystem for filesystem in gfs_cli.list_filesystems()
             if disk_root_part in filesystem
         ]
         if not rootfs:
@@ -477,7 +483,5 @@ def _guestfs_copy_path(guestfs_conn, guest_path, host_path):
                     guest_path,
                     path,
                 ),
-                os.path.join(
-                    host_path, os.path.basename(path)
-                ),
+                os.path.join(host_path, os.path.basename(path)),
             )

--- a/lago/workdir.py
+++ b/lago/workdir.py
@@ -409,7 +409,10 @@ class Workdir(object):
     action='store',
     help='Name of the prefix to set as current',
 )
-@utils.in_prefix(prefix_class=prefix.Prefix, workdir_class=Workdir, )
+@utils.in_prefix(
+    prefix_class=prefix.Prefix,
+    workdir_class=Workdir,
+)
 def set_current(prefix_name, parent_workdir, **kwargs):
     """
     Changes the current to point to the given prefix

--- a/lago_template_repo/__init__.py
+++ b/lago_template_repo/__init__.py
@@ -44,9 +44,7 @@ def do_add(args):
 def do_update(args):
     repos_dir = config.get('template_repos')
     ret, out, _ = utils.run_command(
-        [
-            'find', repos_dir, '-type', 'd', '-name', '.git'
-        ],
+        ['find', repos_dir, '-type', 'd', '-name', '.git'],
     )
 
     for line in [l.strip() for l in out.split('\n') if len(l)]:
@@ -72,17 +70,12 @@ ARGUMENTS = collections.OrderedDict()
 ARGUMENTS[Verbs.ADD] = (
     'Add a git repository with JSON repo files to the directory with repos',
     (
-        (
-            'url',
-            {
-                'help': (
-                    'Path to config that describes the scripts needed to run'
-                ),
-            },
-        ),
+        ('url',
+         {'help': 'Path to config that describes the scripts needed to run'}),
     ),
     do_add,
-)
+)  # yapf: disable
+
 ARGUMENTS[Verbs.UPDATE] = (
     'Update the saved repositories (to origin/master).',
     (),

--- a/ovirtlago/__init__.py
+++ b/ovirtlago/__init__.py
@@ -29,10 +29,20 @@ import nose.config
 from lago.prefix import Prefix
 from lago.workdir import Workdir
 from lago import log_utils
-from . import (paths, testlib, virt, reposetup, )
+from . import (
+    paths,
+    testlib,
+    virt,
+    reposetup,
+)
 
 # TODO: put it into some config
-PROJECTS_LIST = ['vdsm', 'ovirt-engine', 'vdsm-jsonrpc-java', 'ioprocess', ]
+PROJECTS_LIST = [
+    'vdsm',
+    'ovirt-engine',
+    'vdsm-jsonrpc-java',
+    'ioprocess',
+]
 LOGGER = logging.getLogger(__name__)
 LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
 log_task = functools.partial(log_utils.log_task, logger=LOGGER)
@@ -98,11 +108,7 @@ class OvirtPrefix(Prefix):
         engine_dists = [self.virt_env.engine_vm().distro()] \
             if self.virt_env.engine_vm() else []
         vdsm_dists = list(
-            set(
-                [
-                    host.distro() for host in self.virt_env.host_vms()
-                ]
-            )
+            set([host.distro() for host in self.virt_env.host_vms()])
         )
         all_dists = list(set(engine_dists + vdsm_dists))
 
@@ -114,8 +120,7 @@ class OvirtPrefix(Prefix):
                 parser.readfp(repo_conf_fd)
 
             repos = [
-                repo
-                for repo in parser.sections()
+                repo for repo in parser.sections()
                 if repo.split('-')[-1] in all_dists
             ]
 

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -36,11 +36,13 @@ in_ovirt_prefix = in_prefix(
 )
 # TODO: Remove this, and properly complain on unset config values
 CONF_DEFAULTS = {
-    'reposync_dir': '/var/lib/lago/reposync',
-    'reposync_config': (
-        '/usr/share/ovirtlago/config/repos/'
-        'ovirt-master-snapshot-external.repo'
-    ),
+    'reposync_dir':
+        '/var/lib/lago/reposync',
+    'reposync_config':
+        (
+            '/usr/share/ovirtlago/config/repos/'
+            'ovirt-master-snapshot-external.repo'
+        ),
 }
 DISTS = ['el6', 'el7', 'fc20']
 
@@ -236,7 +238,10 @@ def do_ovirt_serve(prefix, **kwargs):
 
 
 def _populate_parser(cli_plugins, parser):
-    verbs_parser = parser.add_subparsers(dest='ovirtverb', metavar='VERB', )
+    verbs_parser = parser.add_subparsers(
+        dest='ovirtverb',
+        metavar='VERB',
+    )
     for cli_plugin_name, plugin in cli_plugins.items():
         plugin_parser = verbs_parser.add_parser(
             cli_plugin_name, **plugin.init_args

--- a/ovirtlago/reposetup.py
+++ b/ovirtlago/reposetup.py
@@ -25,7 +25,10 @@ import logging
 import os
 
 from lago import log_utils
-from lago.utils import (run_command, LockFile, )
+from lago.utils import (
+    run_command,
+    LockFile,
+)
 
 from . import utils
 
@@ -78,7 +81,12 @@ def _fix_reposync_issues(reposync_out, repo_path):
     )
     package_regex = re.compile(r'(?P<package_name>[^:\r\s]+): \[Errno 256\]')
     for match in package_regex.findall(reposync_out):
-        find_command = ['find', repo_path, '-name', match + '*', ]
+        find_command = [
+            'find',
+            repo_path,
+            '-name',
+            match + '*',
+        ]
         ret, out, _ = run_command(find_command)
 
         if ret:
@@ -106,9 +114,7 @@ def sync_rpm_repository(repo_path, yum_config, repos):
         '--newest-only',
         '--delete',
         '--cachedir=%s/cache' % repo_path,
-    ] + [
-        '--repoid=%s' % repo for repo in repos
-    ]
+    ] + ['--repoid=%s' % repo for repo in repos]
 
     with LockFile(lock_path, timeout=180):
         with LogTask('Running reposync'):

--- a/ovirtlago/testlib.py
+++ b/ovirtlago/testlib.py
@@ -75,9 +75,7 @@ def with_ovirt_api4(func):
     @with_ovirt_prefix
     def wrapper(prefix, *args, **kwargs):
         return func(
-            prefix.virt_env.engine_vm().get_api(api_ver=4),
-            *args,
-            **kwargs
+            prefix.virt_env.engine_vm().get_api(api_ver=4), *args, **kwargs
         )
 
     return wrapper
@@ -193,14 +191,12 @@ class TaskLogNosePlugin(nose.plugins.Plugin):
 
     def startTest(self, test):
         log_utils.start_log_task(
-            test.shortDescription() or str(test),
-            logger=self.logger
+            test.shortDescription() or str(test), logger=self.logger
         )
 
     def stopTest(self, test):
         log_utils.end_log_task(
-            test.shortDescription() or str(test),
-            logger=self.logger
+            test.shortDescription() or str(test), logger=self.logger
         )
 
 

--- a/ovirtlago/utils.py
+++ b/ovirtlago/utils.py
@@ -43,7 +43,8 @@ def generate_request_handler(root_dir):
 
         def translate_path(self, path):
             return os.path.join(
-                self.__root_dir, SimpleHTTPRequestHandler.translate_path(
+                self.__root_dir,
+                SimpleHTTPRequestHandler.translate_path(
                     self, path
                 )[len(os.getcwd()):].lstrip('/')
             )

--- a/ovirtlago/virt.py
+++ b/ovirtlago/virt.py
@@ -32,7 +32,10 @@ try:
 except ImportError:
     API_V4 = False
 
-from . import (constants, testlib, )
+from . import (
+    constants,
+    testlib,
+)
 
 
 class OvirtVirtEnv(lago.virt.VirtEnv):
@@ -224,9 +227,8 @@ class EngineVM(lago.vm.DefaultVM):
             self.copy_to(config, 'engine-answer-file')
 
         result = self.interactive_ssh(
-            [
-                'engine-setup',
-            ] + (config and ['--config-append=engine-answer-file'] or []),
+            ['engine-setup', ] +
+            (config and ['--config-append=engine-answer-file'] or []),
         )
         if result.code != 0:
             raise RuntimeError('Failed to setup the engine')

--- a/scripts/check_style.sh
+++ b/scripts/check_style.sh
@@ -16,35 +16,39 @@ if [[ "$files" == "" ]]; then
 fi
 
 yapf --version
+echo "running yapf on the following files:"
+echo "$files"
+# see: https://github.com/google/yapf/issues/325
+# yapf --diff will always exit with '0' as return code
+yapf_diff=$(yapf --style .style.yapf --diff --parallel $files)
 
-git diff \
-    HEAD^ \
-    --name-status \
-| grep -v "^D" \
-| grep "\.py$" \
-| awk '{ print $2 }' \
-| xargs yapf \
-    --style .style.yapf \
-    --diff \
-|| {
+if [[ -n "${yapf_diff// }" ]]; then
+    echo "yapf diff: "
+    echo -e "$yapf_diff\n"
     cat <<EOF
-Yapf failed, make sure to run:
-    yapf --style .style.yapf --in-place --recursive .
+    ***************************************************************************
+    Yapf failed, make sure to run:
+        yapf --style .style.yapf --in-place --recursive .
 
-to format any python files automatically, it is higly recommended that you
-install formatting tools to your editor, check the yapf repo:
+    If you want to make it run faster, on python2 ensure you have 'futures'
+    installed from pip and run:
+        yapf --style .style.yapf --in-place --parallel --recursive .
 
-     https://github.com/google/yapf/tree/master/plugins
+    To format any python files automatically, it is higly recommended that you
+    install formatting tools to your editor, check the yapf repo:
 
-to check for official support (always helpful).
-You can also install the pre-commit hook provided in this repo:
+        https://github.com/google/yapf/tree/master/plugins
 
-    ln -s scripts/pre-commit.style .git/pre-commit
+    To check for official support (always helpful).
+    You can also install the pre-commit hook provided in this repo:
 
-and it will format any files changed at commit time.
+        ln -s scripts/pre-commit.style .git/pre-commit
 
+    and it will format any files changed at commit time.
+    ***************************************************************************
 EOF
     exit 1
-}
+fi
 
+echo "yapf style check: OK"
 exit 0

--- a/scripts/version_manager.py
+++ b/scripts/version_manager.py
@@ -79,13 +79,8 @@ def get_tags(repo):
     return {
         commit: os.path.basename(tag_ref)
         for tag_ref, commit in repo.get_refs().items()
-        if tag_ref.startswith('refs/tags/') and VALID_TAG.match(
-            tag_ref[
-                len(
-                    'refs/tags/'
-                ):
-            ]
-        )
+        if tag_ref.startswith('refs/tags/') and
+        VALID_TAG.match(tag_ref[len('refs/tags/'):])
     }
 
 
@@ -172,8 +167,8 @@ def get_merged_commits(repo, commit, first_parents, children_per_parent):
             merge_children.add(next_sha)
 
         non_first_parents = (
-            parent
-            for parent in next_commit.parents if parent not in first_parents
+            parent for parent in next_commit.parents
+            if parent not in first_parents
         )
         for child_sha in non_first_parents:
             if child_sha not in merge_children and child_sha != next_sha:
@@ -269,7 +264,10 @@ def get_changelog(repo_path, from_commit=None):
             start_including or commit_sha.startswith(from_commit)
             or fuzzy_matches_refs(from_commit, refs.get(commit_sha, []))
         ):
-            cur_line = pretty_commit(commit, version, )
+            cur_line = pretty_commit(
+                commit,
+                version,
+            )
             for child in children:
                 cur_line += pretty_commit(repo.get_object(child), version=None)
             start_including = True

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,8 @@ def get_version(project_dir=os.curdir):
                     version = line.split(' ', 1)[-1]
 
     elif os.path.exists(version_manager):
-        version = check_output(
-            [version_manager, project_dir, 'version']
-        ).strip()
+        version = check_output([version_manager, project_dir, 'version']
+                               ).strip()
 
     if version is None:
         raise RuntimeError('Failed to get package version')
@@ -58,4 +57,7 @@ def get_version(project_dir=os.curdir):
 
 if __name__ == '__main__':
     os.environ['PBR_VERSION'] = get_version()
-    setup(setup_requires=['pbr'], pbr=True, )
+    setup(
+        setup_requires=['pbr'],
+        pbr=True,
+    )

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -16,4 +16,5 @@ stevedore
 xmltodict
 configparser
 pyxdg
-yapf==0.7.1
+futures
+yapf==0.14.0

--- a/tests/unit/lago/test_libvirt_utils.py
+++ b/tests/unit/lago/test_libvirt_utils.py
@@ -24,8 +24,7 @@ import lago.libvirt_utils
 
 class TestDomain(object):
     @pytest.mark.parametrize(
-        'state,expected',
-        [
+        'state,expected', [
             ([state_int, 9], state_desc)
             for state_int, state_desc in
             lago.libvirt_utils.DOMAIN_STATES.items()

--- a/tests/unit/lago/test_utils.py
+++ b/tests/unit/lago/test_utils.py
@@ -63,22 +63,33 @@ class TestDeepCopy(object):
 
 class TestLoadVirtStream(object):
     virt_conf = {
-        'domains': [
-            {
-                'domain01': {
-                    'disks': [
-                        {'name': 'disk1'},
-                        {'name': 'disk2'},
-                    ]
-                },
-                'domain02': {
-                    'disks': [
-                        {'name': 'disk1'},
-                        {'name': 'disk2'},
-                    ]
+        'domains':
+            [
+                {
+                    'domain01':
+                        {
+                            'disks': [
+                                {
+                                    'name': 'disk1'
+                                },
+                                {
+                                    'name': 'disk2'
+                                },
+                            ]
+                        },
+                    'domain02':
+                        {
+                            'disks': [
+                                {
+                                    'name': 'disk1'
+                                },
+                                {
+                                    'name': 'disk2'
+                                },
+                            ]
+                        }
                 }
-            }
-        ]
+            ]
     }
 
     def test_load_yaml(self):

--- a/tests/unit/lago/test_workdir.py
+++ b/tests/unit/lago/test_workdir.py
@@ -33,8 +33,7 @@ import lago.prefix
 def mock_workdir(tmpdir, **kwargs):
     default_props = generate_workdir_props(**kwargs)
     return mock.Mock(
-        spec_set=lago.workdir.Workdir(str(tmpdir)),
-        **default_props
+        spec_set=lago.workdir.Workdir(str(tmpdir)), **default_props
     )
 
 
@@ -378,7 +377,10 @@ class TestWorkdir(object):
         with pytest.raises(AssertionError):
             mock_workdir._set_current.assert_called_with()
 
-    def test__update_current_sets_default_if_there(self, mock_workdir, ):
+    def test__update_current_sets_default_if_there(
+        self,
+        mock_workdir,
+    ):
         mock_workdir.prefixes = {'default': None, 'another': None}
         mock_workdir.current = None
         mock_workdir._update_current = functools.partial(
@@ -665,7 +667,12 @@ class TestWorkdir(object):
             'all prefixes',
         ),
     )
-    def test_destroy(self, mock_workdir, monkeypatch, to_destroy, ):
+    def test_destroy(
+        self,
+        mock_workdir,
+        monkeypatch,
+        to_destroy,
+    ):
         mock_rmtree, mock_workdir = self._destroy_mocks(
             monkeypatch,
             mock_workdir,
@@ -702,7 +709,9 @@ class TestWorkdir(object):
         (
             (
                 os.curdir,
-                {'start_path': 'auto'},
+                {
+                    'start_path': 'auto'
+                },
                 True,
             ),
             (
@@ -712,17 +721,23 @@ class TestWorkdir(object):
             ),
             (
                 '/one/two',
-                {'start_path': '/one/two/three'},
+                {
+                    'start_path': '/one/two/three'
+                },
                 True,
             ),
             (
                 '/one',
-                {'start_path': '/one/two/three'},
+                {
+                    'start_path': '/one/two/three'
+                },
                 True,
             ),
             (
                 'shrubbery',
-                {'start_path': '/one/two/three'},
+                {
+                    'start_path': '/one/two/three'
+                },
                 False,
             ),
         ),
@@ -770,7 +785,9 @@ class TestWorkdir(object):
         (
             (
                 os.curdir,
-                {'start_path': 'auto'},
+                {
+                    'start_path': 'auto'
+                },
                 True,
             ),
             (
@@ -780,7 +797,9 @@ class TestWorkdir(object):
             ),
             (
                 'shrubbery',
-                {'start_path': '/one/two/three'},
+                {
+                    'start_path': '/one/two/three'
+                },
                 False,
             ),
         ),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -62,9 +62,15 @@ def _args_to_parser(args):
 )
 def test_get_env_dict_sections():
     assert config.get_env_dict('lago') == {
-        'lago': {'global_var_1': 'v1'},
-        'section': {'var': 'v2'},
-        'long_section_name': {'long_var_name': 'v3'},
+        'lago': {
+            'global_var_1': 'v1'
+        },
+        'section': {
+            'var': 'v2'
+        },
+        'long_section_name': {
+            'long_var_name': 'v3'
+        },
     }
 
 
@@ -170,12 +176,7 @@ def test_cli_shadows_env(mocked_configs_path):
     assert config_load['arg'] == 'cli'
 
 
-@patch.dict(
-    'lago.config.os.environ', {
-        'LAGO_ARG1': 'env',
-        'LAGO_ARG2': 'env'
-    }
-)
+@patch.dict('lago.config.os.environ', {'LAGO_ARG1': 'env', 'LAGO_ARG2': 'env'})
 @patch('lago.config.open', new_callable=mock_open)
 @patch('lago.config._get_configs_path', return_value=['file1', 'file2'])
 def test_all_sources_root_section(mocked_configs_path, mocked_open):
@@ -183,11 +184,13 @@ def test_all_sources_root_section(mocked_configs_path, mocked_open):
     file2 = {'lago': {'arg1': 'file2', 'arg2': 'file2'}}
     parser = _args_to_parser(
         [
-            ('--arg1', {'default': 'parser'}), (
-                '--arg2', {
-                    'default': 'parser'
-                }
-            ), ('--arg3', {'default': 'parser'})
+            ('--arg1', {
+                'default': 'parser'
+            }), ('--arg2', {
+                'default': 'parser'
+            }), ('--arg3', {
+                'default': 'parser'
+            })
         ]
     )
     args = ['--arg2', 'cli']

--- a/tests/unit/test_dirlock.py
+++ b/tests/unit/test_dirlock.py
@@ -27,7 +27,10 @@ import pytest
 from lago import dirlock
 from lago.dirlock import unlock
 
-LOCK_TYPES = {'inclusive': True, 'exclusive': False, }
+LOCK_TYPES = {
+    'inclusive': True,
+    'exclusive': False,
+}
 
 
 # Helper functions
@@ -76,42 +79,33 @@ def lock_type(request):
 # Tests
 def test_lock_once(lock_dir_path, key_path, lock_type):
     assert dirlock.trylock(
-        path=lock_dir_path,
-        excl=LOCK_TYPES[lock_type],
-        key_path=key_path
+        path=lock_dir_path, excl=LOCK_TYPES[lock_type], key_path=key_path
     )
 
 
 def test_lock_twice(lock_dir_path, key_path, lock_type):
     exclusive = LOCK_TYPES[lock_type]
     assert dirlock.trylock(
-        path=lock_dir_path,
-        excl=exclusive, key_path=key_path
+        path=lock_dir_path, excl=exclusive, key_path=key_path
     )
     if exclusive:
         assert not dirlock.trylock(
-            path=lock_dir_path,
-            excl=exclusive,
-            key_path=key_path
+            path=lock_dir_path, excl=exclusive, key_path=key_path
         )
     else:
         assert dirlock.trylock(
-            path=lock_dir_path,
-            excl=exclusive,
-            key_path=key_path
+            path=lock_dir_path, excl=exclusive, key_path=key_path
         )
 
 
 def test_lock_twice_with_unlock(lock_dir_path, key_path, lock_type):
     exclusive = LOCK_TYPES[lock_type]
     assert dirlock.trylock(
-        path=lock_dir_path,
-        excl=exclusive, key_path=key_path
+        path=lock_dir_path, excl=exclusive, key_path=key_path
     )
     unlock(lock_dir_path, key_path)
     assert dirlock.trylock(
-        path=lock_dir_path,
-        excl=exclusive, key_path=key_path
+        path=lock_dir_path, excl=exclusive, key_path=key_path
     )
 
 


### PR DESCRIPTION
New flake8 versions are no longer compatible with
the old yapf version used.

1. Fixed 2 flake8 errors.
2. Fixed few docstring/RST errors.
3. Adjusted scripts/check_style.sh to the new yapf exit
codes.
4. Rest of the changes were generated by running
the new yapf(0.14.0) on rest of the code.

closes: https://github.com/lago-project/lago/issues/321