### PR TITLE
make reposync more verbose and fix bz 1399235

### DIFF
--- a/ovirtlago/__init__.py
+++ b/ovirtlago/__init__.py
@@ -124,7 +124,7 @@ class OvirtPrefix(Prefix):
                 if repo.split('-')[-1] in all_dists
             ]
 
-            if not skip_sync:
+            if not skip_sync and len(repos) > 0:
                 with LogTask(
                     'Syncing remote repos locally (this might take some time)'
                 ):


### PR DESCRIPTION
Until now we tried deducing the RPM name in reposync errors
from the line printing 'no more mirrors to try', however in the BZ
1399235, it is actually the rpm spec file 'Release' parameter that
is printed.
This could have been due to a change in yum/yum-utils, or we are
now seeing a different error.

This patch attempts to make the 'reposync' stage more robust and
verbose:

1. New regex lookups were added according to the BZ, the old regex
(probably due to yum/yum-utils changes) is looking for a different
error and also sometimes matched incorrect RPM names(which starting with
'^M' sequence).
It attempts to look RPM names according to the fedora guidelines:
https://fedoraproject.org/wiki/How_to_create_an_RPM_package

2. Defected packages lookup will be done inside python instead
of GNU find and when deleting a file, it will be logged and
also printed to stdout.

3. reposync will be called for each repoid separately, this will
allow to easily trace which repository caused the error.

bz: https://bugzilla.redhat.com//show_bug.cgi?id=1399235

@sandrobonazzola  - should probably close https://github.com/lago-project/lago/issues/319, or at least improve it.


Signed-off-by: Nadav Goldin <ngoldin@redhat.com>