### PR TITLE
Create the SCSI controller only if needed.

### DIFF
--- a/lago/dom_template.xml
+++ b/lago/dom_template.xml
@@ -20,9 +20,6 @@
       <memballoon model='none'/>
       <controller type='usb' model='none'>
       </controller>
-      <controller type='scsi' index='0' model='virtio-scsi'>
-        <driver iothread='1'/>
-      </controller>
       <disk type='file' device='disk'>
         <driver name='qemu' type='qcow2'/>
         <source file='DISK_PATH'/>

--- a/lago/vm.py
+++ b/lago/vm.py
@@ -263,6 +263,7 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
         disk = devices.xpath('disk')[0]
         devices.remove(disk)
 
+        scsi_con_exists = False
         for disk_order, dev_spec in enumerate(self.vm._spec['disks']):
 
             # we have to make some adjustments
@@ -280,6 +281,20 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
             # support virtio-scsi - sdX devices
             if dev_spec['dev'].startswith('sd'):
                 bus = 'scsi'
+                if not scsi_con_exists:
+                    controller = lxml.etree.Element(
+                        'controller',
+                        type='scsi',
+                        index='0',
+                        model='virtio-scsi',
+                    )
+                    driver = lxml.etree.Element(
+                        'driver',
+                        iothread='1',
+                    )
+                    controller.append(driver)
+                    devices.append(controller)
+                    scsi_con_exists = True
 
             disk = lxml.etree.Element(
                 'disk',


### PR DESCRIPTION
Not all hosts use virtio-SCSI. No need to create
the SCSI controller if there are not virtio-scsi
disks in the VM definition.