### PR TITLE
ovirtlago: fix bug in capabilities

### DIFF
--- a/ovirtlago/testlib.py
+++ b/ovirtlago/testlib.py
@@ -94,7 +94,7 @@ def _vms_capable(vms, caps):
 
     existing_caps = set()
     for vm in vms:
-        existing_caps.union(get_vm_caps(vm) or [])
+        existing_caps = existing_caps.union(get_vm_caps(vm) or [])
 
     return caps.issubset(existing_caps)
 


### PR DESCRIPTION
The 'ovirt-capabilities' metadata always returned
false because the new returned set from 'union'
operation was not assigned.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>