### PR TITLE
Update firewall configuration instructions

### DIFF
--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -86,4 +86,7 @@ refreshes it's permissions and picks up any newly created users::
 
     $ sudo service libvirtd restart
 
+Iptables must allow internal connection to the internal repository lago publishes:
 
+    $ echo "-A INPUT -p tcp --dport 8585 -j ACCEPT" >> /etc/sysconfig/iptables
+    $ service iptables reload


### PR DESCRIPTION
The local repo lago creates needs to be accessible from intenal connection. 
Machines that uses iptables and not firewalld must have that set.