### PR TITLE
ovirtlago: drop exception handling in test_sequence_gen

### DIFF
--- a/ovirtlago/testlib.py
+++ b/ovirtlago/testlib.py
@@ -81,11 +81,6 @@ def with_ovirt_api4(func):
     return wrapper
 
 
-def continue_on_failure(func):
-    func.continue_on_failure = True
-    return func
-
-
 def _vms_capable(vms, caps):
     caps = set(caps)
 
@@ -128,24 +123,13 @@ def host_capability(caps):
 
 
 def test_sequence_gen(test_list):
-    failure_occured = [False]
     for test in test_list:
 
         def wrapped_test():
-            if failure_occured[0]:
-                raise SkipTest()
-            try:
-                return test()
-            except SkipTest:
-                raise
-            except:
-                if not getattr(test, 'continue_on_failure', False):
-                    failure_occured[0] = True
-                raise
+            test()
 
-        if test is not None:
-            wrapped_test.description = test.__name__
-            yield wrapped_test
+        setattr(wrapped_test, 'description', test.__name__)
+        yield wrapped_test
 
 
 class LogCollectorPlugin(nose.plugins.Plugin):


### PR DESCRIPTION
This patch removes all exception handling that was done
in 'test_seqeuence_gen', instead letting nose handle the
exceptions. Also removing 'continue_on_failure' decorator
which was unused.

Some more details:
1. In OST we call ```test_sequence_gen```  to generate the tests for nose.
2. In the current implementation, which its commits go back to [bitbucket times](https://bitbucket.org/ydary/ovirt-testing-framework/commits/af62d0504dd490602892e6b167f8ef69d06a3338#Ltests/testlib.pyT52), I couldn't find any documents what it is meant to do.
3. What I think it is trying to do:
If you add an attribute ``continue_on_failure`` to any test, it would not stop when exception is raised. On the other side, if an exception occurred it would raise a SkipTest on all tests afterwards.

But, this has few problems:
1. We already run nose with [don't stop](https://github.com/lago-project/lago/blob/48bffab089278a33729a49db62e377b51a64aa8b/ovirtlago/__init__.py#L179) on errors. 
2. It masks exceptions messages.
3. It adds another level of logic which is not coordinated with nose's plugins.
4. I couldn't find any evidence that we used the ``continue_on_failure`` attribute. 

Overall, I think the current implementation interferes with something that should work by it self(nose), so, in this patch I suggest to drop it and make the function a 'stupid' generator.

Example of output with this patch and https://github.com/lago-project/lago/commit/916cd379554dcc328c021f622e93697054f5e63c: 
```bash
> lago ovirt runtest 009_koko.py
current session does not belong to lago group.
@ Run test: 009_koko.py: 
nose.config: INFO: Ignoring files matching ['^\\.', '^_', '^setup\\.py$']
  # _004_pass: 
  # _004_pass: Success (in 0:00:00)
  # _002_skip: 
    * SKIPPED: skipping test!
  # _002_skip: Success (in 0:00:00)
  # _001_pass: 
  # _001_pass: Success (in 0:00:00)
  # _005_should_be_skipped: 
    * SKIPPED: skipping test!
  # _005_should_be_skipped: Success (in 0:00:00)
  # _0001_skip: 
    * SKIPPED: skipping test!
  # _0001_skip: Success (in 0:00:00)
  # _003_exception: 
    * Collect artifacts: 
    * Collect artifacts: ERROR (in 0:00:02)
  # _003_exception: ERROR (in 0:00:02)
  # Results located at /tmp/Lagoz/.lago/default/nosetests-009_koko.py.xml
@ Run test: 009_koko.py: ERROR (in 0:00:02)
Error occured, aborting
...
RuntimeError: Some tests failed 
```

```>cat 009_koko.py```
```python

from nose import SkipTest
from ovirtlago import testlib

def _0001_skip():
    raise SkipTest('skipping test!')

def _001_pass():
    pass

def _002_skip():
    raise SkipTest('skipping test!')

def _003_exception():
    raise Exception('should fail')

def _004_pass():
    pass

def _005_should_be_skipped():
    raise SkipTest('skipping test!')

_test_list = [eval(key) for key in globals().keys() if key.startswith('_00')]
def test_gen():
    for t in testlib.test_sequence_gen(_test_list):
        test_gen.__name__ = t.description
        yield t
```



Signed-off-by: Nadav Goldin <ngoldin@redhat.com>