### PR TITLE
use LIBGUESTFS_BACKEND variable if set

### DIFF
--- a/lago/sysprep.py
+++ b/lago/sysprep.py
@@ -113,7 +113,9 @@ def edit(filename, expression):
 
 def sysprep(disk, mods, backend='direct'):
     cmd = ['virt-sysprep', '-a', disk, '--selinux-relabel']
-    env = dict(os.environ.copy(), LIBGUESTFS_BACKEND=backend)
+    env = os.environ.copy()
+    if 'LIBGUESTFS_BACKEND' not in env:
+        env['LIBGUESTFS_BACKEND'] = backend
     for mod in mods:
         cmd.extend(mod)
 


### PR DESCRIPTION
Until now we always used 'direct' in virt-sysprep command.
With this change:
1. 'direct' will be used if LIBGUESTFS_BACKEND is not set.
2. 'LIBGUESTFS_BACKEND' value will be used if set.

According to the [docs](http://libguestfs.org/guestfs.3.html#backend) libguestfs is usally compiled with the 'direct' backend, but not always. So setting this to 'direct' unless the user explicitly asked something else should be safe.


Signed-off-by: Nadav Goldin <ngoldin@redhat.com>