### PR TITLE
automation: ensure /dev/kvm is created under mock

### DIFF
--- a/automation/check-merged.sh
+++ b/automation/check-merged.sh
@@ -35,6 +35,7 @@ echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
 echo '~*          Running functional tests                   ~'
 echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
 if [[ "$res" == "0" ]]; then
+    ! [[ -c "/dev/kvm" ]] && mknod /dev/kvm c 10 232
     run_full_functional_tests \
     || res=$?
 else

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -3,6 +3,7 @@ EXPORTED_DIR="$PWD/exported-artifacts"
 OUT_DOCS_DIR="$EXPORTED_DIR/docs"
 
 
+
 source "${0%/*}/common.sh"
 
 
@@ -43,6 +44,7 @@ echo '~*          Running basic functional tests             ~'
 echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
 
 if code_changed && [[ "$res" == "0" ]]; then
+    ! [[ -c "/dev/kvm" ]] && mknod /dev/kvm c 10 232
     run_basic_functional_tests \
     || res=$?
 elif [[ "$res" == "0" ]]; then


### PR DESCRIPTION
[DO NOT MERGE] - still testing if this improves CI running times.

This should speed up the functional tests a bit, ensuring
virt-sysprep uses kvm under mock.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>