### PR TITLE
Refactor collect command to use SCP

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -566,17 +566,28 @@ def do_copy_to_vm(prefix, host, remote_path, local_path, **kwargs):
     host.copy_to(local_path, remote_path)
 
 
-@lago.plugins.cli.cli_plugin(help='Collect logs from VMs')
+@lago.plugins.cli.cli_plugin(
+    help=(
+        'Collect logs from VMs, list of collected logs '
+        'can be specified in the init file, under '
+        'artifacts parameter '
+    )
+)
 @lago.plugins.cli.cli_plugin_add_argument(
     '--output',
     help='Path to place all the extracted at',
     required=True,
     type=os.path.abspath,
 )
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--no-skip',
+    help='do not skip missing paths',
+    action='store_true',
+)
 @in_lago_prefix
 @with_logging
-def do_collect(prefix, output, **kwargs):
-    prefix.collect_artifacts(output)
+def do_collect(prefix, output, no_skip, **kwargs):
+    prefix.collect_artifacts(output, ignore_nopath=not no_skip)
 
 
 @lago.plugins.cli.cli_plugin(

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -34,7 +34,7 @@ import os
 import warnings
 from abc import (ABCMeta, abstractmethod)
 
-from scp import SCPClient
+from scp import SCPClient, SCPException
 
 from .. import (
     utils,
@@ -48,11 +48,15 @@ LOGGER = logging.getLogger(__name__)
 LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
 
 
-class VMErrror(Exception):
+class VMError(Exception):
     pass
 
 
-class ExtractPathError(VMErrror):
+class ExtractPathError(VMError):
+    pass
+
+
+class ExtractPathNoPathError(VMError):
     pass
 
 
@@ -179,27 +183,33 @@ class VMProviderPlugin(plugins.Plugin):
         """
         return self.vm.interactive_ssh()
 
-    def extract_paths(self, paths):
+    def extract_paths(self, paths, ignore_nopath):
         """
         Extract the given paths from the domain
 
         Args:
             paths(list of str): paths to extract
+            ignore_nopath(boolean): if True will ignore none existing paths.
+
+        Returns:
+            None
+
+        Raises:
+            :exc:`~lago.plugins.vm.ExtractPathNoPathError`: if a none existing
+                path was found on the VM, and ``ignore_nopath`` is True.
+            :exc:`~lago.plugins.vm.ExtractPathError`: on all other failures.
         """
-        if self.vm.alive() and self.vm.ssh_reachable():
-            self._extract_paths_scp(paths=paths)
-        elif self.vm.alive():
-            raise ExtractPathError(
-                'Unable to extract logs from alive but unreachable host %s. '
-                'Try stopping it first' % self.vm.name()
-            )
+        if self.vm.alive() and self.vm.ssh_reachable(
+            tries=1, propagate_fail=False
+        ):
+            self._extract_paths_scp(paths=paths, ignore_nopath=ignore_nopath)
         else:
             raise ExtractPathError(
-                'Unable to extract logs from alive but unreachable host %s. '
-                'Try stopping it first' % self.vm.name()
+                'Unable to extract paths from {0}: unreachable with SSH'.
+                format(self.vm.name())
             )
 
-    def _extract_paths_scp(self, paths):
+    def _extract_paths_scp(self, paths, ignore_nopath):
         for host_path, guest_path in paths:
             LOGGER.debug(
                 'Extracting scp://%s:%s to %s',
@@ -207,7 +217,18 @@ class VMProviderPlugin(plugins.Plugin):
                 host_path,
                 guest_path,
             )
-            self.vm.copy_from(local_path=guest_path, remote_path=host_path)
+            try:
+                self.vm.copy_from(
+                    local_path=guest_path,
+                    remote_path=host_path,
+                    propagate_fail=False
+                )
+            except SCPException as err:
+                err_sfx = ': No such file or directory'
+                if ignore_nopath and str.endswith(str(err.message), err_sfx):
+                    LOGGER.debug('%s: ignoring', err.message)
+                else:
+                    raise ExtractPathNoPathError(err.message)
 
 
 class VMPlugin(plugins.Plugin):
@@ -317,8 +338,10 @@ class VMPlugin(plugins.Plugin):
                     recursive=recursive,
                 )
 
-    def copy_from(self, remote_path, local_path, recursive=True):
-        with self._scp() as scp:
+    def copy_from(
+        self, remote_path, local_path, recursive=True, propagate_fail=True
+    ):
+        with self._scp(propagate_fail=propagate_fail) as scp:
             scp.get(
                 recursive=recursive,
                 remote_path=remote_path,
@@ -386,11 +409,27 @@ class VMPlugin(plugins.Plugin):
     def alive(self):
         return self.state() == 'running'
 
-    def ssh_reachable(self):
+    @_check_alive
+    def ssh_reachable(self, tries=None, propagate_fail=True):
+        """
+        Check if the VM is reachable with ssh
+
+        Args:
+            tries(int): Number of tries to try connecting to the host
+            propagate_fail(bool): If set to true, this event will appear
+            in the log and fail the outter stage. Otherwise, it will be
+            discarded.
+
+        Returns:
+            bool: True if the VM is reachable.
+        """
+
         try:
             ssh.get_ssh_client(
                 ip_addr=self.ip(),
                 host_name=self.name(),
+                ssh_tries=tries,
+                propagate_fail=propagate_fail,
                 ssh_key=self.virt_env.prefix.paths.ssh_id_rsa(),
                 username=self._spec.get('ssh-user'),
                 password=self._spec.get('ssh-password'),
@@ -452,14 +491,15 @@ class VMPlugin(plugins.Plugin):
 
         return root_password
 
-    def collect_artifacts(self, host_path):
+    def collect_artifacts(self, host_path, ignore_nopath):
         self.extract_paths(
             [
                 (
                     guest_path,
                     os.path.join(host_path, guest_path.replace('/', '_')),
                 ) for guest_path in self._artifact_paths()
-            ]
+            ],
+            ignore_nopath=ignore_nopath
         )
 
     def guest_agent(self):
@@ -512,8 +552,9 @@ class VMPlugin(plugins.Plugin):
         return spec
 
     @contextlib.contextmanager
-    def _scp(self):
+    def _scp(self, propagate_fail=True):
         client = ssh.get_ssh_client(
+            propagate_fail=propagate_fail,
             ip_addr=self.ip(),
             host_name=self.name(),
             ssh_key=self.virt_env.prefix.paths.ssh_id_rsa(),

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -1095,7 +1095,7 @@ class Prefix(object):
         return os.path.isfile(lagofile)
 
     @log_task('Collect artifacts')
-    def collect_artifacts(self, output_dir):
+    def collect_artifacts(self, output_dir, ignore_nopath):
         if os.path.exists(output_dir):
             utils.rotate_dir(output_dir)
 
@@ -1105,7 +1105,7 @@ class Prefix(object):
             with LogTask('%s' % vm.name()):
                 path = os.path.join(output_dir, vm.name())
                 os.makedirs(path)
-                vm.collect_artifacts(path)
+                vm.collect_artifacts(path, ignore_nopath)
 
         utils.invoke_in_parallel(
             _collect_artifacts,

--- a/lago/ssh.py
+++ b/lago/ssh.py
@@ -325,7 +325,7 @@ def get_ssh_client(
     ):
         ssh_timeout = int(config.get('ssh_timeout'))
         if ssh_tries is None:
-            ssh_tries = int(config.get('ssh_tries'))
+            ssh_tries = int(config.get('ssh_tries', 10))
 
         start_time = time.time()
         while ssh_tries > 0:
@@ -364,7 +364,6 @@ def get_ssh_client(
                     host_name,
                     err,
                 )
-
             ssh_tries -= 1
             time.sleep(1)
         else:

--- a/lago/vm.py
+++ b/lago/vm.py
@@ -28,6 +28,7 @@ import pwd
 from . import (log_utils, utils, sysprep, libvirt_utils)
 from .config import config
 from .plugins import vm
+from .plugins.vm import ExtractPathError, ExtractPathNoPathError
 
 LOGGER = logging.getLogger(__name__)
 LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
@@ -199,16 +200,42 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
             if was_defined:
                 self.start()
 
-    def extract_paths(self, paths):
-        if (
-            self.vm.alive() and self.vm.ssh_reachable()
-            and self.vm.has_guest_agent()
-        ):
-            self._extract_paths_live(paths=paths)
-        elif not self.vm.alive():
-            self._extract_paths_dead(paths=paths)
-        else:
-            super(LocalLibvirtVMProvider, self).extract_paths(paths=paths)
+    def extract_paths(self, paths, ignore_nopath):
+        """
+        Extract the given paths from the domain
+
+        Attempt to extract all files defined in ``paths`` with the method
+        defined in :func:`~lago.plugins.vm.VMProviderPlugin.extract_paths`,
+        if it fails, will try extracting the files with libguestfs.
+
+        Args:
+            paths(list of str): paths to extract
+            ignore_nopath(boolean): if True will ignore none existing paths.
+
+        Returns:
+            None
+
+        Raises:
+            :exc:`~lago.plugins.vm.ExtractPathNoPathError`: if a none existing
+                path was found on the VM, and `ignore_nopath` is True.
+            :exc:`~lago.plugins.vm.ExtractPathError`: on all other failures.
+        """
+
+        try:
+
+            super(LocalLibvirtVMProvider, self).extract_paths(
+                paths=paths,
+                ignore_nopath=ignore_nopath,
+            )
+        except ExtractPathError as err:
+            LOGGER.debug(
+                '%s: failed extracting files: %s', self.vm.name(), err.message
+            )
+            LOGGER.debug(
+                '%s: attempting to extract files with libguestfs',
+                self.vm.name()
+            )
+            self._extract_paths_gfs(paths=paths, ignore_nopath=ignore_nopath)
 
     @_check_defined
     def vnc_port(self):
@@ -434,57 +461,48 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
             self._reclaim_disks()
             self.vm._spec['snapshots'][name] = snap_info
 
-    def _extract_paths_live(self, paths, freeze=False):
-        if freeze:
-            dom = self.libvirt_con.lookupByName(self._libvirt_name())
-            self.vm.guest_agent().start()
-            dom.fsFreeze()
-        try:
-            self._extract_paths_dead(paths=paths)
-        finally:
-            if freeze:
-                dom.fsThaw()
-
-    def _extract_paths_dead(self, paths):
-        disk_path = os.path.expandvars(self.vm._spec['disks'][0]['path'])
-        disk_root_part = self.vm._spec['disks'][0]['metadata'].get(
-            'root-partition',
-            'root',
-        )
-
+    def _extract_paths_gfs(self, paths, ignore_nopath):
         gfs_cli = guestfs.GuestFS(python_return_dict=True)
-        gfs_cli.add_drive_opts(disk_path, format='qcow2', readonly=1)
-        gfs_cli.set_backend('direct')
-        gfs_cli.launch()
-        rootfs = [
-            filesystem for filesystem in gfs_cli.list_filesystems()
-            if disk_root_part in filesystem
-        ]
-        if not rootfs:
-            raise RuntimeError(
-                'No root fs (%s) could be found for %s form list %s' %
-                (disk_root_part, disk_path, str(gfs_cli.list_filesystems()))
+        try:
+            disk_path = os.path.expandvars(self.vm._spec['disks'][0]['path'])
+            disk_root_part = self.vm._spec['disks'][0]['metadata'].get(
+                'root-partition',
+                'root',
             )
-        else:
-            rootfs = rootfs[0]
-        gfs_cli.mount_ro(rootfs, '/')
-        for (guest_path, host_path) in paths:
-            LOGGER.debug(
-                'Extracting guestfs://%s:%s to %s',
-                self.vm.name(),
-                host_path,
-                guest_path,
-            )
-            try:
-                _guestfs_copy_path(gfs_cli, guest_path, host_path)
-            except Exception:
-                LOGGER.exception(
-                    'Failed to copy %s from %s',
-                    guest_path,
-                    self.vm.name(),
+            gfs_cli.add_drive_opts(disk_path, format='qcow2', readonly=1)
+            gfs_cli.set_backend(os.environ.get('LIBGUESTFS_BACKEND', 'direct'))
+            gfs_cli.launch()
+            rootfs = [
+                filesystem for filesystem in gfs_cli.list_filesystems()
+                if disk_root_part in filesystem
+            ]
+            if not rootfs:
+                raise RuntimeError(
+                    'No root fs (%s) could be found for %s from list %s' % (
+                        disk_root_part, disk_path,
+                        str(gfs_cli.list_filesystems())
+                    )
                 )
-        gfs_cli.shutdown()
-        gfs_cli.close()
+            else:
+                rootfs = rootfs[0]
+            gfs_cli.mount_ro(rootfs, '/')
+            for (guest_path, host_path) in paths:
+                msg = ('Extracting guestfs://{0}:{1} to {2}').format(
+                    self.vm.name(), host_path, guest_path
+                )
+
+                LOGGER.debug(msg)
+                try:
+                    _guestfs_copy_path(gfs_cli, guest_path, host_path)
+                except ExtractPathNoPathError as err:
+                    if ignore_nopath:
+                        LOGGER.debug('%s: ignoring', err)
+                    else:
+                        raise
+
+        finally:
+            gfs_cli.shutdown()
+            gfs_cli.close()
 
     def _reclaim_disk(self, path):
         if pwd.getpwuid(os.stat(path).st_uid).pw_name == 'qemu':
@@ -513,3 +531,8 @@ def _guestfs_copy_path(guestfs_conn, guest_path, host_path):
                 ),
                 os.path.join(host_path, os.path.basename(path)),
             )
+    else:
+        raise ExtractPathNoPathError(
+            ('unable to extract {0}: path does not '
+             'exist.').format(guest_path)
+        )

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -217,17 +217,34 @@ def do_ovirt_engine_setup(prefix, config, **kwargs):
     prefix.virt_env.engine_vm().engine_setup(config)
 
 
-@cli_plugin(help='Collect logs from running VMs')
+@cli_plugin(
+    help=(
+        'Collect logs from VMs, list of collected logs '
+        'can be specified in the init file, under '
+        'artifacts parameter '
+    )
+)
 @cli_plugin_add_argument(
     '--output',
     help='Path to place all the extracted at',
     required=True,
     type=os.path.abspath,
 )
+@cli_plugin_add_argument(
+    '--no-skip',
+    help='do not skip missing paths',
+    action='store_true',
+)
 @in_ovirt_prefix
 @with_logging
-def do_ovirt_collect(prefix, output, **kwargs):
-    prefix.collect_artifacts(output)
+def do_ovirt_collect(prefix, output, no_skip, **kwargs):
+    warnings.warn(
+        (
+            '\'lago ovirt collect\' is deprecated, redirecting '
+            'to \'lago collect\''
+        )
+    )
+    lago.cmd.do_collect(prefix=prefix, output=output, no_skip=no_skip)
 
 
 @cli_plugin(help='Start the repo server and do nothing')

--- a/ovirtlago/testlib.py
+++ b/ovirtlago/testlib.py
@@ -26,7 +26,7 @@ import unittest.case
 import nose.plugins
 from nose.plugins.skip import SkipTest
 
-from lago import (utils as utils, log_utils as log_utils)
+from lago import (utils, log_utils, cmd as lago_cmd)
 
 import ovirtlago
 
@@ -171,7 +171,11 @@ class LogCollectorPlugin(nose.plugins.Plugin):
     def _addFault(self, test, err):
         suffix = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
         test_name = '%s-%s' % (test.id(), suffix)
-        self._prefix.collect_artifacts(self._prefix.paths.test_logs(test_name))
+        lago_cmd.do_collect(
+            prefix=self._prefix,
+            output=self._prefix.paths.test_logs(test_name),
+            no_skip=False
+        )
 
 
 class TaskLogNosePlugin(nose.plugins.Plugin):

--- a/ovirtlago/virt.py
+++ b/ovirtlago/virt.py
@@ -118,9 +118,6 @@ class NodeVM(lago.vm.DefaultVM):
     def _artifact_paths(self):
         return []
 
-    def collect_artifacts(self, host_path):
-        return
-
     def wait_for_ssh(self):
         return
 

--- a/tests/functional/collect.bats
+++ b/tests/functional/collect.bats
@@ -32,12 +32,20 @@ REPO_NAME="local_tests_repo"
     helpers.run_ok "$LAGOCLI" start
 }
 
-@test "collect: fails if files to collect don't exist" {
+@test "collect: does not fail if files to collect don't exist" {
     common.is_initialized "$WORKDIR" || skip "Workdir not initiated"
     pushd "$FIXTURES"
     outdir="$FIXTURES/output"
     rm -rf "$outdir"
-    helpers.run_nook "$LAGOCLI" collect --output "$outdir"
+    helpers.run_ok "$LAGOCLI" collect --output "$outdir"
+}
+
+@test "collect: fails if files to collect don't exist and no-skip is set" {
+    common.is_initialized "$WORKDIR" || skip "Workdir not initiated"
+    pushd "$FIXTURES"
+    outdir="$FIXTURES/output"
+    rm -rf "$outdir"
+    helpers.run_nook "$LAGOCLI" collect --no-skip --output "$outdir"
 }
 
 


### PR DESCRIPTION
1. Change the default method for extracting files with 'lago collect'
command to SCP. Extracting using libguestfs becomes the fallback
when SSH is not available.
2. Introduce a new option '--no-skip' which will force not skipping
missing paths. If used it will raise a ``ExtractPathNoPathError``
exception if any of the paths does not exist on the host.
3. Drop the option of using fsFreeze/FsThaw when extracting
files with libguestfs.
4. Redirect 'lago ovirt collect' to 'lago collect' and issue a warning
if used directly.
5. Change the functional tests accordingly.

Some more notes:
1. As SCP becomes the first priority - there is no point in keeping the fsFreeze/fsThaw method, because it requires the guest-agent to be running, but we are only able to ensure it is running with SSH(see https://github.com/lago-project/lago/issues/386). 
2. I suggest dropping ``lago ovirt collect`` entirely here in favour of ``lago collect``, as far as I can tell, it is just code duplication. The logs to collect(aka 'artifacts') are defined in the VM. For now I only added a warning and redirection to ``lago collect``.
3. Making the default behaviour ignoring missing paths, is not backward-incompatible IMO(as discussed in https://github.com/lago-project/lago/pull/211) because until now, when extracting paths with libguestfs it did not fail on missing paths as it was supposed to.
4. The SCP module masks 'IOError' with its own ``SCPException``, so I had to parse the exception message, this works but is a little fragile.


Signed-off-by: Nadav Goldin <ngoldin@redhat.com>