### PR TITLE
automation: configure KVM and libguestfs parameters

### DIFF
--- a/automation/check-merged.mounts
+++ b/automation/check-merged.mounts
@@ -1,2 +1,1 @@
-/var/run/libvirt
-/var/lib/lago
+check-patch.mounts

--- a/automation/check-merged.sh
+++ b/automation/check-merged.sh
@@ -35,6 +35,7 @@ echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
 echo '~*          Running functional tests                   ~'
 echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
 if [[ "$res" == "0" ]]; then
+    set_guestfs_params
     run_full_functional_tests \
     || res=$?
 else

--- a/automation/check-patch.mounts
+++ b/automation/check-patch.mounts
@@ -1,1 +1,3 @@
 /var/run/libvirt
+/var/lib/lago
+/dev/shm

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -43,6 +43,7 @@ echo '~*          Running basic functional tests             ~'
 echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
 
 if code_changed && [[ "$res" == "0" ]]; then
+    set_guestfs_params
     run_basic_functional_tests \
     || res=$?
 elif [[ "$res" == "0" ]]; then

--- a/automation/common.sh
+++ b/automation/common.sh
@@ -3,6 +3,21 @@
 # Common functions for the scripts
 #
 
+
+set_guestfs_params() {
+    # see: https://bugzilla.redhat.com/show_bug.cgi?id=1404287
+    export LIBGUESTFS_APPEND="edd=off"
+    # make libguestfs use /dev/shm as tmpdir
+    export LIBGUESTFS_CACHEDIR="/dev/shm"
+    export LIBGUESTFS_TMPDIR="/dev/shm"
+
+    # ensure KVM is enabled under mock
+    ! [[ -c "/dev/kvm" ]] && mknod /dev/kvm c 10 232
+
+    # un-comment this to debug LIBGUESTFS
+    # export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+}
+
 code_changed() {
     if ! [[ -d .git ]]; then
         echo "Not in a git dir, will run all the tests"

--- a/tests/functional/basic.bats
+++ b/tests/functional/basic.bats
@@ -76,7 +76,6 @@ REPO_NAME="local_tests_repo"
     # and that is not seamlesly reachable from out of the chroot by
     # libvirt/kvm
     export BATS_TMPDIR BATS_TEST_DIRNAME
-    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
     helpers.run_ok "$LAGOCLI" \
         init \
         --template-repo-path "$REPO_CONF" \
@@ -97,7 +96,6 @@ REPO_NAME="local_tests_repo"
     # and that is not seamlesly reachable from out of the chroot by
     # libvirt/kvm
     export BATS_TMPDIR BATS_TEST_DIRNAME
-    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
     cd "$FIXTURES"
     for prefix_name in "${PREFIX_NAMES[@]:0:${#PREFIX_NAMES[@]}-1}"; do
         echo "Creating prefix $prefix_name in $WORKDIR"
@@ -123,7 +121,6 @@ REPO_NAME="local_tests_repo"
     # and that is not seamlesly reachable from out of the chroot by
     # libvirt/kvm
     export BATS_TMPDIR BATS_TEST_DIRNAME
-    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
     cd "$FIXTURES"
     prefix_name="${PREFIX_NAMES[@]: -1}"
     echo "Creating prefix $prefix_name in $WORKDIR"
@@ -297,7 +294,6 @@ EOS
     # This is needed to be able to run inside mock, as it uses some temp files
     # and that is not seamlesly reachable from out of the chroot by
     # libvirt/kvm
-    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
     helpers.run_ok "$LAGOCLI" \
         --prefix-name "$PREFIX_NAME" \
         init \

--- a/tests/functional/collect.bats
+++ b/tests/functional/collect.bats
@@ -20,7 +20,6 @@ REPO_NAME="local_tests_repo"
 
     pushd "$FIXTURES"
     export BATS_TMPDIR BATS_TEST_DIRNAME
-    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
     helpers.run_ok "$LAGOCLI" \
         init \
         --template-repo-path "$REPO_CONF" \

--- a/tests/functional/deploy.bats
+++ b/tests/functional/deploy.bats
@@ -15,7 +15,6 @@ REPO_NAME='local_tests_repo'
 
     rm -rf "$WORKDIR"
     pushd "$FIXTURES"
-    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
     export BATS_TMPDIR BATS_TEST_DIRNAME
     rm -rf "$REPO_STORE" "$WORKDIR" "$STORE"
     cp -a "$FIXTURES/store_skel" "$REPO_STORE"

--- a/tests/functional/ovirt.collect.bats
+++ b/tests/functional/ovirt.collect.bats
@@ -14,7 +14,6 @@ WORKDIR="$FIXTURES"/.lago
 
     rm -rf "$WORKDIR"
     pushd "$FIXTURES"
-    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
     helpers.run_ok "$LAGOCLI" \
         init \
         "$suite"

--- a/tests/functional/ovirt.runtest.bats
+++ b/tests/functional/ovirt.runtest.bats
@@ -15,7 +15,6 @@ PREFIX="$WORKDIR/default"
 
     rm -rf "$WORKDIR"
     cd "$FIXTURES"
-    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
     helpers.run_ok "$LAGOCLI" \
         init \
         "$suite"

--- a/tests/functional/snapshot.bats
+++ b/tests/functional/snapshot.bats
@@ -13,7 +13,6 @@ WORKDIR="$FIXTURES"/.lago
 
     rm -rf "$WORKDIR"
     pushd "$FIXTURES"
-    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
     helpers.run_ok "$LAGOCLI" \
         init \
         "$suite"

--- a/tests/functional/start.bats
+++ b/tests/functional/start.bats
@@ -22,7 +22,6 @@ REPO_NAME="local_tests_repo"
     # and that is not seamlesly reachable from out of the chroot by
     # libvirt/kvm
     export BATS_TMPDIR BATS_TEST_DIRNAME
-    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
     cd "$FIXTURES"
     helpers.run_ok "$LAGOCLI" \
         init \


### PR DESCRIPTION
1. Fix for #389
2. Configure libguestfs tmp dir to be /dev/shm for potential
speed improvements in the functional tests.
3. Ensure /dev/kvm device exists under mock(used by libguestfs)
4. Remove export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1 from functional
tests
Signed-off-by: Nadav Goldin <ngoldin@redhat.com>