### PR TITLE
Make the package build on RHEL/CentOS

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -62,6 +62,7 @@ BuildRequires: python-lxml
 BuildRequires: libvirt-python
 BuildRequires: python-enum
 BuildRequires: python-scp
+BuildRequires: python2-rpm-macros
 %if 0%{?fedora} >= 24
 BuildRequires: python2-configparser
 %else


### PR DESCRIPTION
py2_build and py2_install macros are missing on RHEL/CentOS.
Let's define them so that the package can be built on those platforms.