### PR TITLE
Add a function to get all the IPs of a VM

### DIFF
--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -338,6 +338,17 @@ class VMPlugin(plugins.Plugin):
     def ip(self):
         return str(self.virt_env.get_net().resolve(self.name()))
 
+    def all_ips(self):
+        nets = {}
+        ips = []
+        nets = self.virt_env.get_nets()
+        for net in nets.values():
+            mapping = net.mapping()
+            for hostname, ip in mapping.items():
+                if hostname.startswith(self.name()):
+                    ips.append(str(ip))
+        return ips
+
     def ssh(
         self,
         command,

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -345,6 +345,9 @@ class Network(object):
     def resolve(self, name):
         return self._spec['mapping'][name]
 
+    def mapping(self):
+        return self._spec['mapping']
+
     def _libvirt_name(self):
         return self._env.prefixed_name(self.name(), max_length=15)
 


### PR DESCRIPTION
Now that we've started using multiple networks, it's nice to be able to get all IPs of a VM.
Apparently, there's a strange scheme for the names:
The first is <name>, the others are <name-ethX> .

We should probably change it, but regardless, for now this allows getting all IPs.
Something like:
lago-basic-suite-master-engine: ips: [u'192.168.200.3', u'192.168.202.3']

And it'll be used in ovirt-system-tests later, something like:
def _get_host_all_ips(prefix, host_name):
    return prefix.virt_env.get_vm(host_name).all_ips()
