### PR TITLE
Added the ability to export images from a prefix

### DIFF
--- a/automation/common.sh
+++ b/automation/common.sh
@@ -135,7 +135,8 @@ run_basic_functional_tests() {
         tests/functional/status.bats \
         tests/functional/start.bats \
         tests/functional/collect.bats \
-        tests/functional/deploy.bats" \
+        tests/functional/deploy.bats \
+        tests/functional/export.bats" \
     | tee exported-artifacts/functional_tests.tap
     res=${PIPESTATUS[0]}
     return $res
@@ -180,4 +181,3 @@ EOR
 EOR
     echo "~ Report at file://$PWD/exported-artifacts/index.html  ~"
 }
-

--- a/lago/export.py
+++ b/lago/export.py
@@ -1,0 +1,260 @@
+from abc import ABCMeta, abstractmethod
+import logging
+import functools
+import copy
+import os
+from os import path
+import time
+import json
+import shutil
+
+from . import log_utils, utils
+
+LOGGER = logging.getLogger(__name__)
+LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
+
+
+class DiskExportManager(object):
+    """
+    ExportManager object is responsible on the export process of an image
+    from the current Lago prefix.
+
+    DiskExportManger is the base class of specific ExportManagers.
+    Each specific ExportManger is responsible on the export process of an
+    image with a specific type (e.g template, file...)
+
+    Attributes:
+        src (str): Path to the image that should be exported
+        name (str): The name of the exported disk
+        dst (str): The absolute path of the exported disk
+        disk_type (str): The type of the image e.g template, file, empty...
+        disk (dict): Disk attributes (of the disk that should be exported)
+            as found in workdir/current/virt/VM-NAME
+        exported_metadata(dict): A copy of the source disk metadata, this
+            dict should be updated with new values during the export process.
+            do_compress(bool): If true, apply compression to the exported disk.
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, dst, disk_type, disk, do_compress):
+        """
+        Args:
+            dst (str): The absolute path of the exported disk
+            disk_type (str): The type of the image
+                e.g template, file, empty...
+            disk (dict): Disk attributes as found in
+                workdir/current/virt/VM-NAME
+            do_compress(bool): If true, apply compression to the
+                exported disk.
+        """
+        self.src = path.expandvars(disk['path'])
+        self.name = path.basename(self.src)
+        self.dst = path.join(path.expandvars(dst), self.name)
+        self.dist_type = disk_type
+        self.disk = disk
+        self.exported_metadata = copy.deepcopy(disk['metadata'])
+        self.do_compress = do_compress
+
+    @staticmethod
+    def get_instance_by_type(dst, disk, do_compress, *args, **kwargs):
+        """
+        Args:
+            dst (str): The path of the new exported disk.
+                can contain env variables.
+            disk (dict): Disk attributes
+                (of the disk that should be exported) as
+                found in workdir/current/virt/VM-NAME
+            do_compress(bool): If true, apply compression to the exported disk.
+        Returns
+            An instance of a subclass of DiskExportManager which
+            matches the disk type.
+        """
+        disk_type = disk['type']
+        cls = HANDLERS.get(disk_type)
+        if not cls:
+            raise utils.LagoUserException(
+                'Export is not supported for disk type {}'.format(disk_type)
+            )
+        return cls(dst, disk_type, disk, do_compress, *args, **kwargs)
+
+    @abstractmethod
+    def export(self):
+        """
+        This method will handle the export process and should
+        implemented in each subclass.
+        """
+        raise NotImplementedError(
+            'export is an abstract method that should'
+            'be implemented in subclass'
+        )
+
+    def copy(self):
+        """
+        Copy the disk using cp in order to preserves the 'sparse'
+        structure of the file
+        """
+        with LogTask('Copying disk'):
+            utils.cp(self.src, self.dst)
+
+    def sparse(self):
+        """
+        Make the exported images more compact by removing unused space.
+        Please refer to 'virt-sparsify' for more info.
+        """
+        with LogTask('Making disk sparse'):
+            # Removed unused space from the disk
+            utils.sparse(self.dst, self.disk['format'])
+
+    def calc_sha(self, checksum):
+        """
+        Calculate the checksum of the new exported disk, write it to
+        a file, and update this managers 'exported_metadata'.
+
+        Args:
+            checksum(str): The type of the checksum
+        """
+        with LogTask('Calculating {}'.format(checksum)):
+            with open(self.dst + '.hash', 'wt') as f:
+                sha = utils.get_hash(self.dst, checksum)
+                f.write(sha)
+            self.exported_metadata[checksum] = sha
+
+    def compress(self):
+        """
+        Compress the new exported image,
+        Block size was taken from virt-builder page
+        """
+        if not self.do_compress:
+            return
+        with LogTask('Compressing disk'):
+            utils.compress(self.dst, 16777216)
+            os.unlink(self.dst)
+
+    def update_lago_metadata(self):
+        with LogTask('Updating Lago metadata'):
+            self.exported_metadata['size'] = os.stat(self.dst).st_size
+            self.exported_metadata['name'] = self.name
+            self.exported_metadata['version'] = time.strftime("%Y%m%d.0")
+
+    def write_lago_metadata(self):
+        with LogTask('Writing Lago metadata'):
+            with open(self.dst + '.metadata', 'wt') as f:
+                json.dump(self.exported_metadata, f)
+
+
+class TemplateExportManager(DiskExportManager):
+    """
+    TemplateExportManager is responsible exporting images of type template.
+
+    Attributes:
+        See superclass
+    """
+
+    def __init__(self, dst, disk_type, disk, do_compress, *args, **kwargs):
+        super(TemplateExportManager, self).__init__(
+            dst, disk_type, disk, do_compress
+        )
+        self.standalone = kwargs['standalone']
+        self.src_qemu_info = utils.get_qemu_info(self.src, backing_chain=True)
+
+    def rebase(self):
+        """
+        Change the backing-file entry of the exported disk.
+        Please refer to 'qemu-img rebase' manual for more info.
+        """
+        if self.standalone:
+            rebase_msg = 'Merging layered image with base'
+        else:
+            rebase_msg = 'Rebase'
+
+        with LogTask(rebase_msg):
+            if len(self.src_qemu_info) == 1:
+                # Base image (doesn't have predecessors)
+                return
+
+            if self.standalone:
+                # Consolidate the layers and base image
+                utils.qemu_rebase(target=self.dst, backing_file="")
+            else:
+                if len(self.src_qemu_info) > 2:
+                    raise utils.LagoUserException(
+                        'Layered export is currently supported for one '
+                        'layer only.  You can try to use Standalone export.'
+                    )
+                # Put an identifier in the metadata of the copied layer,
+                # this identifier will be used later by Lago in order
+                # to resolve and download the base image
+                parent = self.src_qemu_info[0]['backing-filename']
+                parent = './{}'.format(
+                    os.path.basename(parent.split(':', 1)[1])
+                )
+                utils.qemu_rebase(
+                    target=self.dst, backing_file=parent, safe=False
+                )
+
+    def update_lago_metadata(self):
+        super(TemplateExportManager, self).update_lago_metadata()
+
+        if self.standalone:
+            self.exported_metadata['base'] = 'None'
+        else:
+            self.exported_metadata['base'] = os.path.basename(self.src)
+
+    def export(self):
+        """
+           See DiskExportManager.export
+        """
+        with LogTask('Exporting disk {} to {}'.format(self.name, self.dst)):
+            with utils.RollbackContext() as rollback:
+                rollback.prependDefer(
+                    shutil.rmtree, self.dst, ignore_errors=True
+                )
+                self.copy()
+                self.sparse()
+                self.rebase()
+                self.calc_sha('sha1')
+                self.update_lago_metadata()
+                self.write_lago_metadata()
+                self.compress()
+                rollback.clear()
+
+
+class FileExportManager(DiskExportManager):
+    """
+    FileExportManager is responsible exporting images of type file and empty.
+
+    Attributes:
+        standalone (bool): If true, create a new image which is the result of
+            merging all the layers of src (the image that we want to export).
+        src_qemu_info (dict): Metadata on src which was generated by qemu-img.
+    """
+
+    def __init__(self, dst, disk_type, disk, do_compress, *args, **kwargs):
+        super(FileExportManager, self).__init__(
+            dst, disk_type, disk, do_compress
+        )
+
+    def export(self):
+        """
+            See DiskExportManager.export
+        """
+        with LogTask('Exporting disk {} to {}'.format(self.name, self.dst)):
+            with utils.RollbackContext() as rollback:
+                rollback.prependDefer(
+                    shutil.rmtree, self.dst, ignore_errors=True
+                )
+                self.copy()
+                self.sparse()
+                self.calc_sha('sha1')
+                self.update_lago_metadata()
+                self.write_lago_metadata()
+                self.compress()
+                rollback.clear()
+
+
+HANDLERS = {
+    'file': FileExportManager,
+    'empty': FileExportManager,
+    'template': TemplateExportManager
+}

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -163,6 +163,21 @@ class VMProviderPlugin(plugins.Plugin):
         """
         pass
 
+    def export_disks(self, standalone, dst_dir, compress, *args, **kwargs):
+        """
+        Export 'disks' as a standalone image or a layered image.
+
+        Args:
+            disks(list): The names of the disks to export
+              (None means all the disks)
+            standalone(bool): If true create a copy of the layered image
+              else create a new disk which is a combination of the current
+              layer and the base disk.
+            dst_dir (str): dir to place the exported images
+            compress (bool): if true, compress the exported image.
+        """
+        pass
+
     def interactive_console(self):
         """
         Run an interactive console
@@ -310,6 +325,16 @@ class VMPlugin(plugins.Plugin):
         """
         return self.provider.extract_paths(paths, *args, **kwargs)
 
+    def export_disks(
+        self, standalone=True, dst_dir=None, compress=False, *args, **kwargs
+    ):
+        """
+        Thin method that just uses the provider
+        """
+        return self.provider.export_disks(
+            standalone, dst_dir, compress, *args, **kwargs
+        )
+
     def copy_to(self, local_path, remote_path, recursive=True):
         with LogTask(
             'Copy %s to %s:%s' % (local_path, self.name(), remote_path),
@@ -334,6 +359,10 @@ class VMPlugin(plugins.Plugin):
     @property
     def metadata(self):
         return self._spec['metadata'].copy()
+
+    @property
+    def disks(self):
+        return self._spec['disks'][:]
 
     def name(self):
         return str(self._spec['name'])

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -191,6 +191,34 @@ class VirtEnv(object):
     def bootstrap(self):
         utils.invoke_in_parallel(lambda vm: vm.bootstrap(), self._vms.values())
 
+    def export_vms(self, vms_names, standalone, dst_dir, compress):
+        if not vms_names:
+            vms_names = self._vms.keys()
+
+        running_vms = []
+        vms = []
+        for name in vms_names:
+            try:
+                vm = self._vms[name]
+                vms.append(vm)
+                if vm.defined():
+                    running_vms.append(vm)
+            except KeyError:
+                raise utils.LagoUserException(
+                    'Entity {} does not exist'.format(name)
+                )
+
+        if running_vms:
+            raise utils.LagoUserException(
+                'The following vms must be off:\n{}'.
+                format('\n'.join([_vm.name() for _vm in running_vms]))
+            )
+        # TODO: run the export task in parallel
+
+        with LogTask('Exporting disks to: {}'.format(dst_dir)):
+            for _vm in vms:
+                _vm.export_disks(standalone, dst_dir, compress)
+
     def start(self, vm_names=None):
         if not vm_names:
             log_msg = 'Start Prefix'

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ lago.plugins.cli =
     status=lago.cmd:do_status
     stop=lago.cmd:do_stop
     generate-config=lago.cmd:do_generate
+    export=lago.cmd:do_export
     template-repo=lago_template_repo:TemplateRepoCLI
 
 lago.plugins.output =

--- a/tests/functional/common.bash
+++ b/tests/functional/common.bash
@@ -18,9 +18,25 @@ VERBS=(
     template-repo
     console
     generate-config
+    'export'
 )
 FIXTURES="$BATS_TEST_DIRNAME/fixtures"
 export LAGO__START__WAIT_SUSPEND="1.0"
+
+common.is_stopped() {
+    local workdir="${1?}"
+    local status=$(
+      "$LAGOCLI" \
+          --out-format flat \
+          status
+    )
+    echo "$status" | grep -q "status: up"
+    if [[ $? -ne 0 ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
 
 common.is_initialized() {
     local workdir="${1?}"

--- a/tests/functional/export.bats
+++ b/tests/functional/export.bats
@@ -1,0 +1,166 @@
+#!/usr/bin/env bats -x
+load common
+load helpers
+load env_setup
+
+FIXTURES="$FIXTURES/export"
+CUSTOM_WORKDIR="$FIXTURES/workdir"
+WORKDIR="$FIXTURES/.lago"
+
+REPO_STORE="$FIXTURES"/repo_store
+STORE="$FIXTURES"/store
+REPO_CONF="$FIXTURES"/template_repo.json
+REPO_NAME="local_tests_repo"
+VM_NAME=lago_functional_tests_vm01
+
+SA_ENV="sa_exported_env"
+LAYERED_ENV="layered_exported_env"
+STAND_ALONE_EXPORT_DIR="${FIXTURES}/${SA_ENV}"
+LAYERED_EXPORT_DIR="${FIXTURES}/${LAYERED_ENV}"
+
+# needed in order to run libguestfs inside mock
+export LIBGUESTFS_BACKEND=direct
+
+@test "export.init" {
+    local workdir="$FIXTURES"/workdir
+    local suite="$FIXTURES"/suite.json
+
+    rm -rf "$WORKDIR" "$STORE"
+
+    # This is needed to be able to run inside mock, as it uses some temp files
+    # and that is not seamlesly reachable from out of the chroot by
+    # libvirt/kvm
+    export BATS_TMPDIR BATS_TEST_DIRNAME
+    cd "$FIXTURES"
+
+    helpers.run_ok "$LAGOCLI" \
+        init \
+        --template-repo-path "$REPO_CONF" \
+        --template-repo-name "$REPO_NAME" \
+        --template-store "$STORE" \
+        "$suite"
+
+    # This is needed to be able to run sudo inside the chroot
+    echo 'Defaults:root !requiretty' > /etc/sudoers.d/lago_functional_tests
+}
+
+@test "export.start: start everything at once" {
+    common.is_initialized "$WORKDIR" || skip "workdir not initiated"
+    cd "$FIXTURES"
+    helpers.run_ok "$LAGOCLI" start
+}
+
+@test "export.place_dummy_file" {
+    cd $FIXTURES
+    rm -rf dummy_file
+
+    local content="$(date)"
+    echo "$content" > "dummy_file"
+
+    helpers.run_ok "$LAGOCLI" \
+        copy-to-vm \
+        "$VM_NAME" \
+        dummy_file \
+        /root/dummy_file_inside
+
+    # Just to be sure that the file was written to disk
+    sleep 2
+}
+
+@test "export.fail_to_export_running_env" {
+    cd "$FIXTURES"
+
+    helpers.run_nook "$LAGOCLI" \
+        "export" \
+        --standalone \
+        --dst-dir "$STAND_ALONE_EXPORT_DIR"
+}
+
+@test "export.stop" {
+    cd "$FIXTURES"
+
+    "$LAGOCLI" shell "$VM_NAME" "cd /sbin && ./poweroff"
+    sleep 3
+    common.is_initialized "$WORKDIR" || skip "workdir not initiated"
+    helpers.run_ok "$LAGOCLI" stop
+}
+
+@test "export.export_stand_alone: stand alone images export" {
+    cd "$FIXTURES"
+
+    helpers.run_ok common.is_stopped $WORKDIR
+    helpers.run_ok "$LAGOCLI" \
+        "export" \
+        --standalone \
+        --dst-dir "$STAND_ALONE_EXPORT_DIR"
+}
+
+@test "export.export_layered: layered images export" {
+    cd "$FIXTURES"
+
+    helpers.run_ok common.is_stopped $WORKDIR
+    helpers.run_ok "$LAGOCLI" \
+        "export" \
+        --dst-dir "$LAYERED_EXPORT_DIR"
+}
+
+@test "export.remove_base_env" {
+    cd "$FIXTURES"
+
+    helpers.run_ok "$LAGOCLI" destroy --yes
+}
+
+@test "export.init_exported_sa_env" {
+    cd "$STAND_ALONE_EXPORT_DIR"
+
+    local suite="${FIXTURES}/exported_suite.json"
+    # will be used by exported_suite.json
+    export EXPORTED_ENV=$STAND_ALONE_EXPORT_DIR
+
+    helpers.run_ok "$LAGOCLI" \
+        init \
+        --template-repo-path "$REPO_CONF" \
+        --template-repo-name "$REPO_NAME" \
+        --template-store "$STORE" \
+        "$suite"
+}
+
+@test "export.test_exported_env: testing standalone export" {
+    cd $FIXTURES
+    local dummy_file_content=$(cat dummy_file)
+    cd "$STAND_ALONE_EXPORT_DIR"
+
+    helpers.run_ok "$LAGOCLI" start
+    dummy_file_inside_content=$("$LAGOCLI" shell "$VM_NAME" "cat /root/dummy_file_inside" | tail -n1)
+    helpers.contains "$dummy_file_inside_content" "$dummy_file_content"
+}
+
+@test "export.stop_exported_env: destroying standalone export env" {
+    cd "$STAND_ALONE_EXPORT_DIR"
+    helpers.run_ok "$LAGOCLI" destroy --yes
+}
+
+@test "export.init_exported_layered_env" {
+    cd "$LAYERED_EXPORT_DIR"
+
+    local suite="${FIXTURES}/exported_suite.json"
+    # will be used by exported_suite.json
+    export EXPORTED_ENV=$LAYERED_EXPORT_DIR
+
+    helpers.run_ok "$LAGOCLI" \
+        init \
+        --template-repo-path "$REPO_CONF" \
+        --template-repo-name "$REPO_NAME" \
+        --template-store "$STORE" \
+        "$suite"
+}
+
+@test "export.test_exported_env: testing layered export" {
+    cd $FIXTURES
+    local dummy_file_content=$(cat dummy_file)
+    cd "$LAYERED_EXPORT_DIR"
+
+    helpers.run_ok "$LAGOCLI" start
+    dummy_file_inside_content=$("$LAGOCLI" shell "$VM_NAME" "cat /root/dummy_file_inside")
+    helpers.contains "$dummy_file_inside_content" "$dummy_file_content"
+}

--- a/tests/functional/fixtures/export/exported_suite.json
+++ b/tests/functional/fixtures/export/exported_suite.json
@@ -1,0 +1,32 @@
+{
+    "domains": {
+        "lago_functional_tests_vm01": {
+            "memory": 64,
+            "nics": [
+                {
+                    "net": "lago_functional_tests"
+                }
+            ],
+            "disks": [
+                {
+                    "type": "template",
+                    "template_type": "qcow2",
+                    "path": "$EXPORTED_ENV/lago_functional_tests_vm01_root.qcow2",
+                    "name": "root",
+                    "dev": "vda",
+                    "format": "qcow2"
+                }
+            ]
+        }
+    },
+    "nets": {
+        "lago_functional_tests": {
+            "type": "nat",
+            "dhcp": {
+                "start": 100,
+                "end": 254
+            },
+            "management": true
+        }
+    }
+}

--- a/tests/functional/fixtures/export/repo_store/vm0_root.qcow2.hash
+++ b/tests/functional/fixtures/export/repo_store/vm0_root.qcow2.hash
@@ -1,0 +1,1 @@
+e793b4f520f66faaf5b5583897c9ac34fb0fa4af

--- a/tests/functional/fixtures/export/store_skel/vm0_root.qcow2.hash
+++ b/tests/functional/fixtures/export/store_skel/vm0_root.qcow2.hash
@@ -1,0 +1,1 @@
+e793b4f520f66faaf5b5583897c9ac34fb0fa4af

--- a/tests/functional/fixtures/export/store_skel/vm0_root.qcow2.metadata
+++ b/tests/functional/fixtures/export/store_skel/vm0_root.qcow2.metadata
@@ -1,0 +1,5 @@
+{
+    "root-password": "cowswin:)",
+    "distro": "cirros",
+    "root-partition": "/dev/sda1"
+}

--- a/tests/functional/fixtures/export/suite.json
+++ b/tests/functional/fixtures/export/suite.json
@@ -1,0 +1,31 @@
+{
+    "domains": {
+        "lago_functional_tests_vm01": {
+            "memory": 64,
+            "nics": [
+                {
+                    "net": "lago_functional_tests"
+                }
+            ],
+            "disks": [
+                {
+                    "template_name": "lago_functional_tests",
+                    "type": "template",
+                    "name": "root",
+                    "dev": "vda",
+                    "format": "qcow2"
+                }
+            ]
+        }
+    },
+    "nets": {
+        "lago_functional_tests": {
+            "type": "nat",
+            "dhcp": {
+                "start": 100,
+                "end": 254
+            },
+            "management": true
+        }
+    }
+}

--- a/tests/functional/fixtures/export/template_repo.json
+++ b/tests/functional/fixtures/export/template_repo.json
@@ -1,0 +1,24 @@
+{
+  "templates": {
+    "lago_functional_tests": {
+      "versions": {
+        "v1": {
+          "source": "local_tests",
+          "handle": "vm0_root.qcow2",
+          "timestamp": 1428328144
+        }
+      }
+    }
+  },
+  "sources": {
+    "local_tests": {
+      "args": {
+        "root":
+            "$BATS_TEST_DIRNAME/fixtures/basic/repo_store"
+      },
+      "type": "file"
+    }
+  },
+  "name": "local_tests_repo"
+}
+


### PR DESCRIPTION
1. Added the ability to export images from the current prefix,
   either as  a layered image or as a base image (Lago will create a
   new image which is a merge of the layer and its base).
   When exporting the image as a layer, the path to his parent will
   be replaced with the current directory, relative to the path of the
   exported image (in simple words, it expect that the parent will be with
   him in the same directory). All this logic can be found in export.py.

2. Added the ability to resolve the parent of a layered image
   (for now only one level, and only for "template_type=qcow2").
   Lago will check if the parent is in the cache, if not it will
   download it from the template repo that was provided, and then
   create a symlink from the layer's directory to the parent.

3. When using a file based disk, allow the user to choose between
   using the actual file, or let Lago make a copy of the disk.
   The default is to use the actual file, and it can be changed through
   the init file with specifying 'make_a_copy=true' under the disk
   section.

4. Added some utility functions to support the flow that was explained
   above.

5. Moved hash calculation function from templates.py to utils.py.

6. Added a verification to 'qemu-img convert' in template.py.

7. Added functional tests for the new feature.

Signed-off-by: gbenhaim <galbh2@gmail.com>

closes https://github.com/lago-project/lago/issues/160