### PR TITLE
Revert usage of 'ssh-inject' in sysprep

### DIFF
--- a/lago/sysprep.py
+++ b/lago/sysprep.py
@@ -56,11 +56,25 @@ def set_iscsi_initiator_name(name):
     )
 
 
-def add_ssh_key(key):
+def add_ssh_key(key, with_restorecon_fix=False):
     extra_options = (
-        '--ssh-inject',
-        'root:file:%s' % key,
-    )
+        '--mkdir',
+        _DOT_SSH,
+        '--chmod',
+        '0700:%s' % _DOT_SSH,
+    ) + _upload_file(_AUTHORIZED_KEYS, key)
+    if (not os.stat(key).st_uid == 0 or not os.stat(key).st_gid == 0):
+        extra_options += (
+            '--run-command',
+            'chown root.root %s' % _AUTHORIZED_KEYS,
+        )
+    if with_restorecon_fix:
+        # Fix for fc23 not relabeling on boot
+        # https://bugzilla.redhat.com/1049656
+        extra_options += (
+            '--firstboot-command',
+            'restorecon -R /root/.ssh',
+        )
     return extra_options
 
 


### PR DESCRIPTION
https://github.com/lago-project/lago/pull/395 added an enhancement of using  virt-sysprep 'ssh-inject'. Turns out this feature is only available in libguestfs >v1.30, until we sort out how that version is consumed on el7.2(or if we drop support for el7.2), I suggest to revert it. Later we can reapply this and also add the version requirement to the spec file.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>