### PR TITLE
ovirtlago: allow running reposync with custom_sources only

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -744,12 +744,6 @@ def create_parser(cli_plugins, out_plugins):
         default='/var/lib/lago/reposync',
         help='Reposync dir if used',
     )
-    parser.add_argument(
-        '--reposync-config',
-        help='Reposync config',
-        default='config.repo',
-        action='store',
-    )
 
     parser.add_argument('--ignore-warnings', action='store_true')
     parser.set_defaults(**config.get_section('lago', {}))

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -35,15 +35,6 @@ in_ovirt_prefix = in_prefix(
     workdir_class=ovirtlago.OvirtWorkdir,
 )
 # TODO: Remove this, and properly complain on unset config values
-CONF_DEFAULTS = {
-    'reposync_dir':
-        '/var/lib/lago/reposync',
-    'reposync_config':
-        (
-            '/usr/share/ovirtlago/config/repos/'
-            'ovirt-master-snapshot-external.repo'
-        ),
-}
 DISTS = ['el6', 'el7', 'fc20']
 
 
@@ -120,6 +111,7 @@ def do_ovirt_runtest(prefix, test_file, **kwargs):
     '--reposync-yum-config',
     help=('Path to configuration to use when updating local rpm repository'),
     type=os.path.abspath,
+    default=None,
 )
 @cli_plugin_add_argument(
     '--skip-sync',
@@ -159,22 +151,12 @@ def do_ovirt_reposetup(
         warnings.warn('Deprecated option --vdsm-dir ignored')
     if kwargs['ioprocess_dir']:
         warnings.warn('Deprecated option --ioprocess-dir ignored')
-
-    rpm_repo = (
-        rpm_repo
-        or lago_config.get('reposync_dir', CONF_DEFAULTS['reposync_dir'])
-    )
-
-    reposync_config = (
-        reposync_yum_config or lago_config.get(
-            'reposync_config',
-            CONF_DEFAULTS['reposync_config'],
-        )
-    )
+    if rpm_repo is None:
+        rpm_repo = lago_config['reposync_dir']
 
     prefix.prepare_repo(
         rpm_repo=rpm_repo,
-        reposync_yum_config=reposync_config,
+        reposync_yum_config=reposync_yum_config,
         skip_sync=skip_sync,
         custom_sources=custom_sources,
     )


### PR DESCRIPTION
This fixes a small bug, when the 'reposync' configuration
was passed but didn't exist, the 'ovirt reposetup' command
failed.

fixes: https://github.com/lago-project/lago/issues/368

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>