### PR TITLE
Force usage of qemu-kvm-ev on centos/rhel

### DIFF
--- a/automation/check-merged.repos.el7
+++ b/automation/check-merged.repos.el7
@@ -1,0 +1,1 @@
+check-patch.repos.el7

--- a/automation/check-patch.repos.el7
+++ b/automation/check-patch.repos.el7
@@ -1,0 +1,2 @@
+ovirt-ci-tools,http://resources.ovirt.org/repos/ci-tools/$distro
+centos-qemu-ev,http://mirror.centos.org/centos/7/virt/x86_64/kvm-common/

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -19,7 +19,8 @@ For Fedora::
   enabled=1
   gpgcheck=0
 
-For EL distros (such as CentOS, RHEL, etc.), make sure you have EPEL and::
+For EL distros (such as CentOS, RHEL, etc.), make sure you have epel-release
+and centos-release-qemu-ev repositories installed and enabled, and::
 
   [lago]
   baseurl=http://resources.ovirt.org/repos/lago/stable/0.0/rpm/el$releasever

--- a/lago.spec.in
+++ b/lago.spec.in
@@ -101,8 +101,13 @@ Requires: python2-configparser
 %else
 Requires: python-configparser
 %endif
+%if 0%{?rhel}
+Requires: qemu-img-rhev >= 2.1.2
+Requires: qemu-kvm-rhev >= 2.1.2
+%else
 Requires: qemu-img >= 2.1.2
 Requires: qemu-kvm >= 2.1.2
+%endif
 Requires: git
 Requires: sudo
 %{?python_provide:%python_provide python2-lago}


### PR DESCRIPTION
Lago requires qemu-kvm >= 2.1.2 and on centos/rhel those versions
are provided by qemu-kvm-ev.