### PR TITLE
workaround for cirros images not getting ip on boot

### DIFF
--- a/tests/functional/common.bash
+++ b/tests/functional/common.bash
@@ -19,6 +19,7 @@ VERBS=(
     generate-config
 )
 FIXTURES="$BATS_TEST_DIRNAME/fixtures"
+export LAGO__START__WAIT_SUSPEND="1.0"
 
 
 common.is_initialized() {


### PR DESCRIPTION
When 'LAGO__START__WAIT_SUSPEND' environment variable value
is set to a float or integer, each domain will be started
in 'paused' mode(CPU halted), and it will be resumed
after waiting for the value set.

This is currently not added to the CLI, as hopefully
this workaround will be removed once the BZ is fixed.

bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=1411025

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>