### PR TITLE
Custom repoman configuration

### DIFF
--- a/ovirtlago/__init__.py
+++ b/ovirtlago/__init__.py
@@ -60,6 +60,7 @@ class OvirtPrefix(Prefix):
         dists,
         repos_path,
         repo_names,
+        repoman_config,
         custom_sources=None,
         projects_list=None,
     ):
@@ -93,6 +94,7 @@ class OvirtPrefix(Prefix):
         reposetup.merge(
             output_dir=self.paths.internal_repo(),
             sources=custom_sources + rpm_dirs,
+            repoman_config=repoman_config,
         )
 
     @log_task('Create prefix internal repo')
@@ -100,6 +102,7 @@ class OvirtPrefix(Prefix):
         self,
         rpm_repo=None,
         reposync_yum_config=None,
+        repoman_config=None,
         skip_sync=False,
         custom_sources=None
     ):
@@ -157,6 +160,7 @@ class OvirtPrefix(Prefix):
             dists=all_dists,
             repos_path=rpm_repo,
             repo_names=repos,
+            repoman_config=repoman_config,
             custom_sources=custom_sources or [],
         )
         self.save()

--- a/ovirtlago/__init__.py
+++ b/ovirtlago/__init__.py
@@ -61,14 +61,16 @@ class OvirtPrefix(Prefix):
         repos_path,
         repo_names,
         repoman_config,
+        repoman_filter,
         custom_sources=None,
         projects_list=None,
     ):
 
         if not projects_list:
             projects_list = PROJECTS_LIST
-
-        custom_sources = custom_sources or []
+        custom_sources = [
+            '{0}{1}'.format(src, repoman_filter) for src in custom_sources
+        ]
 
         rpm_dirs = []
         for dist in dists:
@@ -79,14 +81,14 @@ class OvirtPrefix(Prefix):
 
             rpm_dirs.extend(
                 [
-                    os.path.join(folder, dist) + ':only-missing'
+                    os.path.join(folder, dist) + repoman_filter
                     for folder in project_roots if os.path.exists(folder)
                 ]
             )
 
             rpm_dirs.extend(
                 [
-                    os.path.join(repos_path, name) + ':only-missing'
+                    os.path.join(repos_path, name) + repoman_filter
                     for name in repo_names if name.endswith(dist)
                 ],
             )
@@ -100,6 +102,7 @@ class OvirtPrefix(Prefix):
     @log_task('Create prefix internal repo')
     def prepare_repo(
         self,
+        repoman_filter,
         rpm_repo=None,
         reposync_yum_config=None,
         repoman_config=None,
@@ -161,6 +164,7 @@ class OvirtPrefix(Prefix):
             repos_path=rpm_repo,
             repo_names=repos,
             repoman_config=repoman_config,
+            repoman_filter=repoman_filter,
             custom_sources=custom_sources or [],
         )
         self.save()

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -139,10 +139,21 @@ def do_ovirt_runtest(prefix, test_file, **kwargs):
     dest='custom_sources',
     action='append',
 )
+@cli_plugin_add_argument(
+    '--repoman-config',
+    help=(
+        'Custom repoman configuration file. If not passed defaults will be '
+        'used. Note that \'store.RPMStore.rpm_dir\' is not configurable.'
+    ),
+    dest='repoman_config',
+    action='store',
+    default=None,
+)
 @in_ovirt_prefix
 @with_logging
 def do_ovirt_reposetup(
-    prefix, rpm_repo, reposync_yum_config, skip_sync, custom_sources, **kwargs
+    prefix, rpm_repo, reposync_yum_config, repoman_config, skip_sync,
+    custom_sources, **kwargs
 ):
 
     if kwargs['engine_dir']:
@@ -159,6 +170,7 @@ def do_ovirt_reposetup(
         reposync_yum_config=reposync_yum_config,
         skip_sync=skip_sync,
         custom_sources=custom_sources,
+        repoman_config=repoman_config,
     )
 
 

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -119,18 +119,6 @@ def do_ovirt_runtest(prefix, test_file, **kwargs):
     action='store_true',
 )
 @cli_plugin_add_argument(
-    '--engine-dir',
-    help=('Deprecated, left here for backwards compatibility'),
-)
-@cli_plugin_add_argument(
-    '--vdsm-dir',
-    help=('Deprecated, left here for backwards compatibility'),
-)
-@cli_plugin_add_argument(
-    '--ioprocess-dir',
-    help=('Deprecated, left here for backwards compatibility'),
-)
-@cli_plugin_add_argument(
     '--custom-source',
     help=(
         'Add an extra rpm source to the repo (will have priority over the '
@@ -156,12 +144,6 @@ def do_ovirt_reposetup(
     custom_sources, **kwargs
 ):
 
-    if kwargs['engine_dir']:
-        warnings.warn('Deprecated option --engine-dir ignored')
-    if kwargs['vdsm_dir']:
-        warnings.warn('Deprecated option --vdsm-dir ignored')
-    if kwargs['ioprocess_dir']:
-        warnings.warn('Deprecated option --ioprocess-dir ignored')
     if rpm_repo is None:
         rpm_repo = lago_config['reposync_dir']
 

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -137,11 +137,23 @@ def do_ovirt_runtest(prefix, test_file, **kwargs):
     action='store',
     default=None,
 )
+@cli_plugin_add_argument(
+    '--repoman-filter',
+    help=(
+        'repoman filter to use on every epository configured in '
+        'reposync-yum-config file or passed in --custom-source.'
+        'For valid filters see: '
+        'http://repoman.rtfd.io/en/latest/repoman.common.filters.html'
+    ),
+    dest='repoman_filter',
+    action='store',
+    default=':only-missing',
+)
 @in_ovirt_prefix
 @with_logging
 def do_ovirt_reposetup(
-    prefix, rpm_repo, reposync_yum_config, repoman_config, skip_sync,
-    custom_sources, **kwargs
+    prefix, rpm_repo, reposync_yum_config, repoman_config, repoman_filter,
+    skip_sync, custom_sources, **kwargs
 ):
 
     if rpm_repo is None:
@@ -150,6 +162,7 @@ def do_ovirt_reposetup(
     prefix.prepare_repo(
         rpm_repo=rpm_repo,
         reposync_yum_config=reposync_yum_config,
+        repoman_filter=repoman_filter,
         skip_sync=skip_sync,
         custom_sources=custom_sources,
         repoman_config=repoman_config,

--- a/ovirtlago/reposetup.py
+++ b/ovirtlago/reposetup.py
@@ -78,7 +78,9 @@ def merge(output_dir, sources, repoman_config=None):
     if repoman_config is None:
         repoman_params = [
             '--option=main.on_empty_source=warn',
-            '--option=store.RPMStore.on_wrong_distro=copy_to_all'
+            '--option=store.RPMStore.on_wrong_distro=copy_to_all',
+            '--option=store.RPMStore.with_srcrpms=false',
+            '--option=store.RPMStore.with_sources=false',
         ]
         cmd = ['repoman'] + repoman_params + cmd_suffix
     else:


### PR DESCRIPTION
1. Add optional '--repoman-config' option to ``lago ovirt reposetup``, this will allow overriding the defaults global configuration of repoman.
2. Don't download source RPMs in the default repoman configuration.
3. Allow passing custom **global** repoman filter, the default is still ``:only-missing``.
4. Remove old warning messages.
