### PR TITLE
Allow to define custom cpu model

### DIFF
--- a/lago/virt.py
+++ b/lago/virt.py
@@ -100,6 +100,11 @@ class VirtEnv(object):
         with open(self.prefix.paths.uuid(), 'r') as uuid_fd:
             self.uuid = uuid_fd.read().strip()
 
+        libvirt_url = config.get('libvirt_url')
+        self.libvirt_con = libvirt_utils.get_libvirt_connection(
+            name=self.uuid + libvirt_url,
+            libvirt_url=libvirt_url,
+        )
         self._nets = {}
         for name, spec in net_specs.items():
             self._nets[name] = self._create_net(spec)
@@ -107,12 +112,6 @@ class VirtEnv(object):
         self._vms = {}
         for name, spec in vm_specs.items():
             self._vms[name] = self._create_vm(spec)
-
-        libvirt_url = config.get('libvirt_url')
-        self.libvirt_con = libvirt_utils.get_libvirt_connection(
-            name=self.uuid + libvirt_url,
-            libvirt_url=libvirt_url,
-        )
 
     def get_cpu_model(self):
         cap_tree = lxml.etree.fromstring(self.libvirt_con.getCapabilities())

--- a/lago/vm.py
+++ b/lago/vm.py
@@ -91,6 +91,9 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
             name=self.vm.virt_env.uuid + libvirt_url,
             libvirt_url=libvirt_url,
         )
+        self._cpu_model = self.vm._spec.get(
+            'cpu_model', self.vm.virt_env.get_compatible_cpu_and_family()[0]
+        )
 
     def start(self):
         super(LocalLibvirtVMProvider, self).start()
@@ -284,6 +287,16 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
         ]
         return utils.run_interactive_command(command=virsh_command, )
 
+    @property
+    def cpu_model(self):
+        """
+        Return the VM CPU model for domain XML generation
+
+        Returns:
+            str: cpu model
+        """
+        return self._cpu_model
+
     def _libvirt_name(self):
         return self.vm.virt_env.prefixed_name(self.vm.name())
 
@@ -312,7 +325,7 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
             '@NAME@': self._libvirt_name(),
             '@VCPU@': self.vm._spec.get('vcpu', 2),
             '@CPU@': self.vm._spec.get('cpu', 2),
-            '@CPUMODEL@': self.vm.virt_env.get_compatible_cpu_and_family()[0],
+            '@CPUMODEL@': self.cpu_model,
             '@MEM_SIZE@': self.vm._spec.get('memory', 16 * 1024),
             '@QEMU_KVM@': qemu_kvm_path,
         }

--- a/ovirtlago/virt.py
+++ b/ovirtlago/virt.py
@@ -43,7 +43,6 @@ class OvirtVirtEnv(lago.virt.VirtEnv):
     def __init__(self, prefix, vm_specs, net_spec):
         self._engine_vm = None
         self._host_vms = []
-        self._ovirt_cpu_family = None
         super(OvirtVirtEnv, self).__init__(prefix, vm_specs, net_spec)
 
     def _create_vm(self, vm_spec):
@@ -86,9 +85,6 @@ class OvirtVirtEnv(lago.virt.VirtEnv):
 
     def host_vms(self):
         return self._host_vms[:]
-
-    def get_ovirt_cpu_family(self):
-        return super(OvirtVirtEnv, self).get_compatible_cpu_and_family()[1]
 
 
 # TODO : solve the problem of ssh to the Node


### PR DESCRIPTION
This PR adds a 'cpu_model' parameter to the init file. If defined, it will generate the domain XML with that cpu_model, otherwise it will use the environment defaults. 
There will be 2 options to define the cpu model:
1. By defining it in the init file as noted above. 
2. By creating a new VM plugin and overriding the ``cpu_model`` property. This could allow to create more complex CPU model detections if needed.


 

