### PR TITLE
Add command to generate ansible hosts file

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -18,6 +18,7 @@
 #
 # Refer to the README and COPYING files for full details of the license
 #
+from __future__ import print_function
 
 import argparse
 import grp
@@ -295,7 +296,7 @@ def do_stop(prefix, vm_names, **kwargs):
 def do_snapshot(prefix, list_only, snapshot_name, out_format, **kwargs):
     if list_only:
         snapshots = prefix.get_snapshots()
-        print out_format.format(snapshots)
+        print(out_format.format(snapshots))
     elif snapshot_name:
         prefix.create_snapshots(snapshot_name)
     else:
@@ -501,7 +502,7 @@ def do_status(prefix, out_format, **kwargs):
             },
     }
 
-    print out_format.format(info_dict)
+    print(out_format.format(info_dict))
 
 
 @lago.plugins.cli.cli_plugin(
@@ -529,7 +530,7 @@ def do_list(
             workdir.load()
             resources = workdir.prefixes.keys()
 
-    print out_format.format(resources)
+    print(out_format.format(resources))
 
 
 @lago.plugins.cli.cli_plugin(
@@ -659,7 +660,7 @@ def do_deploy(prefix, **kwargs):
     default=False,
 )
 def do_generate(defaults_only, verbose, **kwargs):
-    print config.get_ini(defaults_only=defaults_only, incl_unset=verbose)
+    print(config.get_ini(defaults_only=defaults_only, incl_unset=verbose))
 
 
 def create_parser(cli_plugins, out_plugins):

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ lago.plugins.cli =
     copy-to-vm=lago.cmd:do_copy_to_vm
     deploy=lago.cmd:do_deploy
     destroy=lago.cmd:do_destroy
+    ansible_hosts=lago.cmd:do_generate_ansible_hosts
     init=lago.cmd:do_init
     list=lago.cmd:do_list
     ovirt=ovirtlago.cmd:OvirtCLI

--- a/tests/functional/common.bash
+++ b/tests/functional/common.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 LAGOCLI=lago
 VERBS=(
+    ansible_hosts
     cleanup
     collect
     copy-from-vm


### PR DESCRIPTION
This patch add support generate ansible hosts file, which reflect the hosts created by lago.

This will be usefull to integrate with Ansible instead of bash or python scripts.