### PR TITLE
Revert "ovirtlago: allow passing custom repoman filters"

### DIFF
--- a/ovirtlago/__init__.py
+++ b/ovirtlago/__init__.py
@@ -61,16 +61,14 @@ class OvirtPrefix(Prefix):
         repos_path,
         repo_names,
         repoman_config,
-        repoman_filter,
         custom_sources=None,
         projects_list=None,
     ):
 
         if not projects_list:
             projects_list = PROJECTS_LIST
-        custom_sources = [
-            '{0}{1}'.format(src, repoman_filter) for src in custom_sources
-        ]
+
+        custom_sources = custom_sources or []
 
         rpm_dirs = []
         for dist in dists:
@@ -81,14 +79,14 @@ class OvirtPrefix(Prefix):
 
             rpm_dirs.extend(
                 [
-                    os.path.join(folder, dist) + repoman_filter
+                    os.path.join(folder, dist) + ':only-missing'
                     for folder in project_roots if os.path.exists(folder)
                 ]
             )
 
             rpm_dirs.extend(
                 [
-                    os.path.join(repos_path, name) + repoman_filter
+                    os.path.join(repos_path, name) + ':only-missing'
                     for name in repo_names if name.endswith(dist)
                 ],
             )
@@ -102,7 +100,6 @@ class OvirtPrefix(Prefix):
     @log_task('Create prefix internal repo')
     def prepare_repo(
         self,
-        repoman_filter,
         rpm_repo=None,
         reposync_yum_config=None,
         repoman_config=None,
@@ -164,7 +161,6 @@ class OvirtPrefix(Prefix):
             repos_path=rpm_repo,
             repo_names=repos,
             repoman_config=repoman_config,
-            repoman_filter=repoman_filter,
             custom_sources=custom_sources or [],
         )
         self.save()

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -137,23 +137,11 @@ def do_ovirt_runtest(prefix, test_file, **kwargs):
     action='store',
     default=None,
 )
-@cli_plugin_add_argument(
-    '--repoman-filter',
-    help=(
-        'repoman filter to use on every epository configured in '
-        'reposync-yum-config file or passed in --custom-source.'
-        'For valid filters see: '
-        'http://repoman.rtfd.io/en/latest/repoman.common.filters.html'
-    ),
-    dest='repoman_filter',
-    action='store',
-    default=':only-missing',
-)
 @in_ovirt_prefix
 @with_logging
 def do_ovirt_reposetup(
-    prefix, rpm_repo, reposync_yum_config, repoman_config, repoman_filter,
-    skip_sync, custom_sources, **kwargs
+    prefix, rpm_repo, reposync_yum_config, repoman_config, skip_sync,
+    custom_sources, **kwargs
 ):
 
     if rpm_repo is None:
@@ -162,7 +150,6 @@ def do_ovirt_reposetup(
     prefix.prepare_repo(
         rpm_repo=rpm_repo,
         reposync_yum_config=reposync_yum_config,
-        repoman_filter=repoman_filter,
         skip_sync=skip_sync,
         custom_sources=custom_sources,
         repoman_config=repoman_config,


### PR DESCRIPTION
This reverts commit 208bfc34051e6f6d6783e353c22868ff035ff7cd.

This patch needs rework because it adds filters to the "extra_source" file.
for example:

2017-01-17 19:55:04,604::INFO::repoman.cmd::Adding artifacts to the repo /home/jenkins/workspace/rhv_4.0_system-tests/ovirt-system-tests/deployment-rhv-suite-4.0/default/internal_repo
Traceback (most recent call last):
  File "/bin/repoman", line 10, in <module>
    sys.exit(main())
  File "/usr/lib/python2.7/site-packages/repoman/cmd.py", line 416, in main
    exit_code = do_add(args, config, repo)
  File "/usr/lib/python2.7/site-packages/repoman/cmd.py", line 307, in do_add
    repo.add_source(art_src.strip())
  File "/usr/lib/python2.7/site-packages/repoman/common/repo.py", line 122, in add_source
    with open(artifact_source.split(':', 1)[1]) as conf_file_fd:
IOError: [Errno 2] No such file or directory: '/home/jenkins/workspace/rhv_4.0_system-tests/ovirt-system-tests/rhv-suite-4.0/extra_sources:only-missing'