### PR TITLE
add uuid to run_command and LogTask

### DIFF
--- a/lago/utils.py
+++ b/lago/utils.py
@@ -222,12 +222,6 @@ def run_command(
             env=env,
             **kwargs
         )
-
-        LOGGER.debug('command exit with %d', command_result.code)
-        if command_result.out:
-            LOGGER.debug('command stdout: %s', command_result.out)
-        if command_result.err:
-            LOGGER.debug('command stderr: %s', command_result.err)
         return command_result
 
 


### PR DESCRIPTION
This PR adds a uuid attribute to each LogTask class instance, and for each run_command. It allows to re-use the generated uuid in LogTask in run_command. This will allow to more easily debug long-running tasks, from the commit message:
```
This patch will generate a uuid and log it on each call to
'_run_command' method. It also allows to reuse an existing uuid.
This is useful in debugging long-running commands(such as repoman),
especially with the combination of hitting 'shift+*' while the cursor
is standing on the uuid(in VIM at least).

Example:
	run_command(['ls', '-lsah'])

lago.log:
... ::DEBUG::start task:c62d45f1-bae6-40d7-95fa-277b0a5d6305:Run command: "ls" "-lsah":
... ::DEBUG::c62d45f1-bae6-40d7-95fa-277b0a5d6305: command exit with return code: 0
... ::DEBUG::c62d45f1-bae6-40d7-95fa-277b0a5d6305: command stdout: total 44K
4.0K drwxrwxr-x.  3 ngoldin ngoldin 4.0K Jan 22 18:57 .

...

... ::DEBUG::end task:c62d45f1-bae6-40d7-95fa-277b0a5d6305:Run command: "ls" "-lsah":
```

We already use uuid in ``lago/ssh.py``, but there we truncate them to 8 chars, which at first is what I also wanted to do(as I thought what are the chances to hit the same 8 random sequences in the same lago run), but there seems to be a consensus that truncating uuids is not safe, and this goes to the log file anyways, so I kept it like this for now.

