### PR TITLE
Add a get method to retrieve the SSH public key contents.

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -1040,6 +1040,19 @@ class Prefix(object):
         """
         return self.virt_env.get_nets()
 
+    def get_ssh_pub_key(self):
+        """
+        Returns the contents of the SSH public key.
+        To be used to install hosts with public key, or
+        set cloud-init configuration with public key, or
+        for Ansible integration
+
+        Returns:
+            str: SSH public key
+        """
+        with open(self.paths.ssh_id_rsa_pub()) as pub_key:
+            return pub_key.read()
+
     @classmethod
     def resolve_prefix_path(cls, start_path=None):
         """


### PR DESCRIPTION
This will be used later to install hosts using public key, for Ansible, etc.