### PR TITLE
Enforce python2-crypto version

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -50,6 +50,12 @@ install -p -D -m 644 etc/firewalld/services/* %{buildroot}%{_sysconfdir}/firewal
 %package -n python-%{name}
 Summary: Library to perform lago operations
 BuildArch: noarch
+
+%if 0%{?fedora} == 24
+Requires: python2-crypto = 2.6.1-10.fc24
+BuildRequires: python2-crypto = 2.6.1-10.fc24
+%endif
+
 BuildRequires: python2-devel
 BuildRequires: python-stevedore
 BuildRequires: python-setuptools


### PR DESCRIPTION
python2-crypto-2.6.1-13.fc24 breaks python2-paramiko-1.16.0-1.fc24, thus
Lago's ssh isn't working on fc24.

A temporary solution is to lock the version of python2-crypto.

Signed-off-by: gbenhaim <galbh2@gmail.com>