### PR TITLE
tests: functional tests fixes 

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -50,6 +50,15 @@ install -p -D -m 644 etc/firewalld/services/* %{buildroot}%{_sysconfdir}/firewal
 %package -n python-%{name}
 Summary: Library to perform lago operations
 BuildArch: noarch
+
+# workaround for BZ: 1419312, 1418084
+%if 0%{?fedora} == 24
+BuildRequires: python2-crypto = 2.6.1-10.fc24
+%endif
+%if 0%{?rhel}
+BuildRequires: python2-crypto = 2.6.1-10.el7
+%endif
+
 BuildRequires: python2-devel
 BuildRequires: python-stevedore
 BuildRequires: python-setuptools
@@ -79,6 +88,15 @@ BuildRequires: python-dulwich
 BuildRequires: python-flake8
 BuildRequires: python-nose
 BuildRequires: git
+
+
+# workaround for BZ: 1419312, 1418084
+%if 0%{?fedora} == 24
+Requires: python2-crypto = 2.6.1-10.fc24
+%endif
+%if 0%{?rhel}
+Requires: python2-crypto = 2.6.1-10.el7
+%endif
 Requires: python
 Requires: libguestfs-tools
 Requires: libvirt >= 1.2.8

--- a/tests/functional/fixtures/ovirt.runtest/suite.yaml
+++ b/tests/functional/fixtures/ovirt.runtest/suite.yaml
@@ -3,7 +3,7 @@ common-host-settings: &common-host-settings
   nics:
     - net: lago_functional_tests
   disks:
-    - template_name: fc23-base
+    - template_name: fc24-base
       type: template
       name: root
       dev: vda

--- a/tests/functional/fixtures/snapshot/1host_1disk_list
+++ b/tests/functional/fixtures/snapshot/1host_1disk_list
@@ -2,18 +2,24 @@
     "lago_functional_tests_vm01": {
         "snapshot_number_1": [
             {
-                "dev": "vda", 
-                "format": "qcow2", 
+                "dev": "vda",
+                "format": "qcow2",
                 "metadata": {
-                    "arch": "x86_64", 
-                    "base": "fedora-23", 
-                    "distro": "fc23", 
-                    "expand": "/dev/sda3", 
-                    "name": "lago Fedora\u00ae 23", 
-                    "osinfo": "fedora23", 
-                    "root-partition": "/dev/sda3"
-                }, 
-                "path": "@@PREFIX_PATH@@/images/lago_functional_tests_vm01_root.qcow2", 
+                    "arch": "x86_64",
+                    "base": "libguestfs:centos-7.3",
+                    "distro": "el7",
+                    "expand": "/dev/sda2",
+                    "id": "el7.3-base",
+                    "lvexpand": "/dev/cl/root",
+                    "name": "el7.3-base",
+                    "osinfo": "centos7.3",
+                    "root-partition": "/dev/cl/root",
+                    "sha1": "652abb087078934a6acb4d102606f1d1866dc7b9",
+                    "sha512": "da516e7f552767f0d28942f5cdc63809b83238dc6ec08f5b096d0b6e7dea1a0e09563785eea5ebb1c014ca8d5f44a3fdb0c26e8f8674427da5f821e67b07826f",
+                    "size": 1780088832,
+                    "version": "v1"
+                },
+                "path": "@@PREFIX_PATH@@/images/lago_functional_tests_vm01_root.qcow2",
                 "type": "template"
             }
         ]

--- a/tests/functional/fixtures/snapshot/1host_1disk_status
+++ b/tests/functional/fixtures/snapshot/1host_1disk_status
@@ -12,7 +12,7 @@
                 [eth0]:
                     ip: @@IP@@
                     network: lago_functional_tests
-            distro: fc23
+            distro: el7
             root password: 123456
             snapshots: snapshot_number_1
             status: running

--- a/tests/functional/fixtures/snapshot/suite_1host_1disk.yaml
+++ b/tests/functional/fixtures/snapshot/suite_1host_1disk.yaml
@@ -4,7 +4,7 @@ domains:
       nics:
         - net: lago_functional_tests
       disks:
-        - template_name: fc23-base
+        - template_name: el7.3-base
           type: template
           name: root
           dev: vda

--- a/tests/functional/ovirt.basic.bats
+++ b/tests/functional/ovirt.basic.bats
@@ -3,6 +3,7 @@ load common
 load ovirt_common
 load helpers
 
+unset LAGO__START__WAIT_SUSPEND
 
 @test "ovirt.basic: command shows help" {
     helpers.run_ok \

--- a/tests/functional/ovirt.runtest.bats
+++ b/tests/functional/ovirt.runtest.bats
@@ -8,6 +8,7 @@ FIXTURES="$FIXTURES/ovirt.runtest"
 WORKDIR="$FIXTURES"/.lago
 PREFIX="$WORKDIR/default"
 
+unset LAGO__START__WAIT_SUSPEND
 
 @test "ovirt.runtest: setup" {
     # As there's no way to know the last test result, we will handle it here

--- a/tests/functional/snapshot.bats
+++ b/tests/functional/snapshot.bats
@@ -6,6 +6,7 @@ load env_setup
 FIXTURES="$FIXTURES/snapshot"
 WORKDIR="$FIXTURES"/.lago
 
+unset LAGO__START__WAIT_SUSPEND
 
 @test "snapshot.1host_1disk: setup" {
     # As there's no way to know the last test result, we will handle it here


### PR DESCRIPTION
1. Enable "cirros dhcp hack" only on tests that use it.
2. Switch tested VMs distros:
``ovirt.runtest``: fc23 -> fc24
``snapshot``: fc23 -> el7.3-base

effort to fix: https://github.com/lago-project/lago/issues/439