### PR TITLE
safely check qemu uid after snapshot

### DIFF
--- a/lago/vm.py
+++ b/lago/vm.py
@@ -534,10 +534,15 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
             gfs_cli.close()
 
     def _reclaim_disk(self, path):
-        if pwd.getpwuid(os.stat(path).st_uid).pw_name == 'qemu':
+        qemu_uid = None
+        try:
+            qemu_uid = pwd.getpwnam('qemu').pw_uid
+        except KeyError:
+            pass
+        if qemu_uid is not None and os.stat(path).st_uid == qemu_uid:
             utils.run_command(['sudo', '-u', 'qemu', 'chmod', 'a+rw', path])
         else:
-            os.chmod(path, 0666)
+            os.chmod(path, 0o0666)
 
     def _reclaim_disks(self):
         for disk in self.vm._spec['disks']:


### PR DESCRIPTION
In situations where lago runs under a container(or mock),
we might bind-mount the images directory into the container,
and then the images might be in an unknown uid/gid, therefore it
is not safe to compare their uid's against the environment users
database. This patch ensures the check is safe. Note that if
the caller does not have sufficient privileges, it will fail(as needed).

closes: https://github.com/lago-project/lago/issues/447

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>