### PR TITLE
Change lazy_refcounts to ON in the snapshots, move to virtio-console, add multiple queues to virtio-scsi

### DIFF
--- a/lago/dom_template.xml
+++ b/lago/dom_template.xml
@@ -17,6 +17,7 @@
       <acpi/>
       <apic/>
       <pae/>
+      <vmport state='off'/>
     </features>
     <devices>
       <emulator>@QEMU_KVM@</emulator>
@@ -36,11 +37,8 @@
         <backend model='random'>/dev/random</backend>
         <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
       </rng>
-      <serial type='pty'>
-        <target port='0'/>
-      </serial>
       <console type='pty'>
-        <target type='serial' port='0'/>
+        <target type='virtio' port='0'/>
       </console>
       <video>
         <model type='cirrus' vram='16384' heads='1'/>

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -717,8 +717,10 @@ class Prefix(object):
             template_store.get_stored_metadata(template_version, ),
         )
         base = template_store.get_path(template_version)
-        qemu_cmd = ['qemu-img', 'create', '-f', 'qcow2', '-b', base, disk_path]
-
+        qemu_cmd = [
+            'qemu-img', 'create', '-f', 'qcow2', '-o', 'lazy_refcounts=on',
+            '-b', base, disk_path
+        ]
         return qemu_cmd, disk_metadata, base
 
     def _ova_to_spec(self, filename):

--- a/lago/vm.py
+++ b/lago/vm.py
@@ -365,7 +365,7 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
 
             # we have to make some adjustments
             # we use iso to indicate cdrom
-            # but the ilbvirt wants it named raw
+            # but libvirt wants it named raw
             # and we need to use cdrom device
             disk_device = 'disk'
             bus = 'virtio'
@@ -387,7 +387,7 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
                     )
                     driver = lxml.etree.Element(
                         'driver',
-                        iothread='1',
+                        queues='{}'.format(self.vm._spec.get('vcpu', 2)),
                     )
                     controller.append(driver)
                     devices.append(controller)


### PR DESCRIPTION
1. This in theory should improve performance. I did not measure much,
but I'm running in RAM / SSD, so can't expect much.
2. Hopefully virtio-console improves performance a bit over regular console.