### PR TITLE
Revert bfea3cc4d104381cd6e5a2ffd9d325843f5ac5f0 - stop on failures

### DIFF
--- a/ovirtlago/__init__.py
+++ b/ovirtlago/__init__.py
@@ -199,7 +199,7 @@ class OvirtPrefix(Prefix):
                 env=env,
                 plugins=nose.core.DefaultPluginManager(),
                 stream=DummyStream(),
-                stopOnError=False,
+                stopOnError=True,
             )
             addplugins = [
                 testlib.TaskLogNosePlugin(),


### PR DESCRIPTION
This reverts:
commit bfea3cc4d104381cd6e5a2ffd9d325843f5ac5f0
Author: Yaniv Kaul <ykaul@redhat.com>
Date:   Wed Oct 5 12:02:11 2016 +0300

    Continue testing on test failures.

It is better to fail than spam the log with further failures.