### PR TITLE
Print informative message when no workdir is found

### DIFF
--- a/tests/unit/lago/test_workdir.py
+++ b/tests/unit/lago/test_workdir.py
@@ -27,6 +27,7 @@ import mock
 
 import lago.workdir
 import lago.prefix
+from lago.utils import LagoUserException
 
 
 @pytest.fixture()
@@ -772,7 +773,7 @@ class TestWorkdir(object):
         )
 
         if not should_be_found:
-            with pytest.raises(RuntimeError):
+            with pytest.raises(LagoUserException):
                 mock_workdir_cls.resolve_workdir_path(**params)
             return
 
@@ -830,7 +831,7 @@ class TestWorkdir(object):
         )
 
         if not should_be_found:
-            with pytest.raises(RuntimeError):
+            with pytest.raises(LagoUserException):
                 mock_workdir_cls.resolve_workdir_path(**params)
             return
 


### PR DESCRIPTION
On failure to find a workdir, look for the following patterns:
1. 'current_path/*/current'
2. 'current_path/*/.lago'

Then quickly evaluate for each one of them if they can be a workdir,
if so, append their truncated paths to the exception message, so the
user could change directory to there.

Fixes: https://github.com/lago-project/lago/issues/451
Signed-off-by: Nadav Goldin <ngoldin@redhat.com>