### PR TITLE
Adding basic video device

### DIFF
--- a/lago/dom_template.xml
+++ b/lago/dom_template.xml
@@ -42,6 +42,11 @@
       <console type='pty'>
         <target type='serial' port='0'/>
       </console>
+      <video>
+        <model type='cirrus' vram='16384' heads='1'/>
+        <alias name='video0'/>
+        <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+      </video>
     </devices>
     <clock offset='utc'>
       <timer name='kvmclock'>


### PR DESCRIPTION
Some images will need a video device to boot,
so adding a simple video device.

Signed-off-by: gbenhaim <galbh2@gmail.com>