### PR TITLE
[WIP] Adding Lago repo plugin

### DIFF
--- a/lago/plugins/repo.py
+++ b/lago/plugins/repo.py
@@ -1,0 +1,76 @@
+"""
+repo plugins
+============
+Common interface for managing vm's repos with Lago
+
+"""
+
+from abc import ABCMeta, abstractmethod
+from lago.plugins import Plugin, NoSuchPluginError
+import lago
+import lago.utils as utils
+import re
+
+REPO_PLUGINS = {}
+DISTRO_TO_PKG_MANAGER = {'el': 'yum', 'fc': 'dnf'}
+
+
+def get_cls_by_distro(distro):
+    global REPO_PLUGINS
+    if not REPO_PLUGINS:
+        REPO_PLUGINS = lago.plugins.load_plugins(
+            'lago.plugins.repo', instantiate=False
+        )
+
+    for candidate_distro, pkg_manager in DISTRO_TO_PKG_MANAGER.viewitems():
+        pattern = r'^' + candidate_distro + r'[0-9]*$'
+        if re.match(pattern, distro):
+            return REPO_PLUGINS[DISTRO_TO_PKG_MANAGER[candidate_distro]]
+
+    raise NoSuchPluginError(
+        'Repo plugin for distro {} does not exist'.format(distro)
+    )
+
+
+def get_cls(pkg_manger):
+    if pkg_manger not in REPO_PLUGINS:
+        raise NoSuchPluginError(pkg_manger)
+
+    return REPO_PLUGINS[pkg_manger]
+
+
+class RepoPlugin(Plugin):
+    __metaclass__ = ABCMeta
+
+    def __init__(self, vm):
+        """
+        Base class for repo plugins
+
+        Args:
+            vm(lago.plugins.VMPlugin): vm to wrap
+
+        Returns:
+            None
+        """
+        self.vm = vm
+        self.mgmt_nets = vm.mgmt_nets()
+
+    @abstractmethod
+    def inject(self, *args, **kwargs):
+        raise NotImplemented
+
+    @abstractmethod
+    def add(self, *args, **kwargs):
+        raise NotImplemented
+
+    @abstractmethod
+    def inject_local_repo(self, *args, **kwargs):
+        raise NotImplemented
+
+    @abstractmethod
+    def add_local_repo(self, *args, **kwargs):
+        raise NotImplemented
+
+
+class RepoPluginUserError(utils.LagoUserException):
+    pass

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -500,6 +500,17 @@ class VMPlugin(plugins.Plugin):
     def nets(self):
         return [nic['net'] for nic in self._spec['nics']]
 
+    def mgmt_nets(self):
+        """
+        Return a list of management networks of self
+
+        Returns:
+            list of virt.Network
+
+        """
+        net_objects = [self.virt_env.get_net(net) for net in self.nets()]
+        return filter(lambda x: x.is_management(), net_objects)
+
     def distro(self):
         distro = self._spec.get('distro', None)
         if distro is None:

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -1325,3 +1325,15 @@ class Prefix(object):
         utils.invoke_in_parallel(
             self._deploy_host, self.virt_env.get_vms().values()
         )
+
+    def get_vms(self, names=None):
+        return self.virt_env.get_vms_value(names)
+
+
+def get_vms(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        kwargs['vms'] = kwargs['prefix'].get_vms(kwargs['vm_names'])
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/lago/repo.py
+++ b/lago/repo.py
@@ -1,0 +1,268 @@
+from lago.cmd import in_lago_prefix
+from lago.plugins.cli import (CLIPlugin, cli_plugin_add_argument)
+from lago.plugins.repo import RepoPluginUserError
+from lago.repo_utils import (
+    generate_repo, remove_sections_by_pattern, add_to_conf,
+    strip_excludes_from_conf, collect_values, add_option_to_sections
+)
+from lago.utils import with_logging
+import configparser
+import functools
+import lago.plugins
+import lago.plugins.repo as repo_plugin
+import logging
+import log_utils
+import prefix
+import StringIO
+
+LOGGER = logging.getLogger(__name__)
+LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
+
+
+class Yum(repo_plugin.RepoPlugin):
+
+    # Maybe add it to the config file
+    config_dir = '/etc/yum.conf'
+
+    def __init__(self, vm):
+        super(Yum, self).__init__(vm)
+        self.guest_config = None
+        self._get_guest_conf()
+
+    def _get_guest_conf(self):
+        LOGGER.debug('Reading repo conf from {}'.format(self.vm.name()))
+        result = self.vm.ssh(['cat', self.config_dir])
+        # TODO: add error checking
+        result = unicode(result.out)
+        self.guest_config = configparser.ConfigParser()
+        self.guest_config.read_string(result)
+
+    def _set_guest_conf(self):
+        with LogTask('Writing repo conf to {}'.format(self.vm.name())):
+            string_io = StringIO.StringIO()
+            self.guest_config.write(string_io, space_around_delimiters=False)
+            cmd = 'echo "{}"'.format(string_io.getvalue())
+            # TODO: add error checking
+            result = self.vm.ssh([cmd, '> {}'.format(self.config_dir)])
+
+    def add_local_repo(self, url=None, inject=False, *args, **kwargs):
+        with LogTask('Adding local repo to {}'.format(self.vm.name())):
+            if (not url) and (not self.mgmt_nets):
+                raise RepoPluginUserError(
+                    'url was not specified and no management network '
+                    'could be found, please specify the url of the local repo'
+                )
+
+            # TODO: Take default repo port from config
+            url = url or 'http://{}:8585/{}'.format(
+                self.mgmt_nets.pop().gw(), self.vm.distro()
+            )
+            # TODO: Take repo specs from cmd
+            repo = generate_repo(
+                'local_repo', url, enabled=1, gpgcheck='0', cost='1'
+            )
+
+            if inject:
+                self.guest_config = remove_sections_by_pattern(
+                    self.guest_config, r'^main$', negative=True
+                )
+                self.guest_config.set('main', 'reposdir', '/dev/null')
+
+            self.guest_config = add_to_conf(self.guest_config, repo)
+            self._set_guest_conf()
+
+    def add(self, config, strip_excludes, set_exclusive, *args, **kwargs):
+        other_config = configparser.ConfigParser()
+        other_config.read(config)
+
+        if strip_excludes:
+            strip_excludes_from_conf(other_config)
+
+        if set_exclusive:
+            include_set = collect_values(other_config, 'includepkgs')
+            add_option_to_sections(
+                self.guest_config,
+                'exclude',
+                ' '.join(include_set),
+                pattern=r'^main$',
+                negative=True
+            )
+
+        self.guest_config = add_to_conf(self.guest_config, other_config)
+        self._set_guest_conf()
+
+    def inject(self, config, strip_excludes, *args, **kwargs):
+        other_config = configparser.ConfigParser()
+        other_config.read(config)
+        if strip_excludes:
+            strip_excludes_from_conf(other_config)
+
+        self.guest_config = other_config
+        self._set_guest_conf()
+
+    def inject_local_repo(self, url, *args, **kwargs):
+        self.add_local_repo(url, inject=True)
+
+
+class Dnf(Yum):
+    pass
+
+
+def pkg_managers(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        managers = [
+            repo_plugin.get_cls_by_distro(vm.distro())(vm)
+            for vm in kwargs['vms']
+        ]
+        kwargs['pkg_managers'] = managers
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@lago.plugins.cli.cli_plugin(
+    help='Inject the given full configuration to a vm, '
+    'Overriding all other configuration.'
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--vm-names',
+    help='The names of the vms which this command is going to effect.'
+    'if no name is specified, this command is going to effect on '
+    'all the vms in the prefix',
+    nargs='*',
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--strip-excludes',
+    help='Strips exclude directives from configuration before adding.',
+    action='store_true',
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    'config',
+    help='The config to inject. could be a string or a file',
+)
+@in_lago_prefix
+@prefix.get_vms
+@with_logging
+@pkg_managers
+def do_inject(prefix, pkg_managers, config, strip_excludes, **kwargs):
+    for manager in pkg_managers:
+        with LogTask('Injecting repo config to {}'.format(manager.vm.name())):
+            manager.inject(config, strip_excludes)
+
+
+@lago.plugins.cli.cli_plugin(
+    help='Add the given yum configuration to the guest existing configuration'
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--vm-names',
+    help='The names of the vms which this command is going to effect.'
+    'if no name is specified, this command is going to effect on '
+    'all the vms in the prefix',
+    nargs='*',
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--strip-excludes',
+    help='Strips exclude directives from configuration before adding.',
+    action='store_true',
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--set-exclusive',
+    help='Insures that all packages that are included in the added repos '
+    'are excluded from all the guest pre-existing repos',
+    action='store_true',
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    'config',
+    help='The config to inject. could be a string or a file',
+)
+@in_lago_prefix
+@prefix.get_vms
+@with_logging
+@pkg_managers
+def do_add(
+    prefix, pkg_managers, config, strip_excludes, set_exclusive, **kwargs
+):
+    for manager in pkg_managers:
+        with LogTask('Adding repo config to {}'.format(manager.vm.name())):
+            manager.add(config, strip_excludes, set_exclusive)
+
+
+@lago.plugins.cli.cli_plugin(
+    help='Replace all guest yum configuration with a configuration that only '
+    'includes a local repository'
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--url',
+    help='The url of the local repo',
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--vm-names',
+    help='The names of the vms which this command is going to effect.'
+    'if no name is specified, this command is going to effect on '
+    'all the vms in the prefix',
+    nargs='*',
+)
+@in_lago_prefix
+@prefix.get_vms
+@with_logging
+@pkg_managers
+def do_inject_local_repo(prefix, pkg_managers, url, **kwargs):
+    for manager in pkg_managers:
+        with LogTask(
+            'Injecting local repo config to {}'.format(manager.vm.name())
+        ):
+            manager.inject_local_repo(url)
+
+
+@lago.plugins.cli.cli_plugin(
+    help='Add local repository to guest existing configuration'
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--url',
+    help='The url of the local repo',
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--vm-names',
+    help='The names of the vms which this command is going to effect.'
+    'if no name is specified, this command is going to effect on '
+    'all the vms in the prefix',
+    nargs='*',
+)
+@in_lago_prefix
+@prefix.get_vms
+@with_logging
+@pkg_managers
+def do_add_local_repo(prefix, pkg_managers, url, **kwargs):
+    for manager in pkg_managers:
+        with LogTask(
+            'Adding local repo config to {}'.format(manager.vm.name())
+        ):
+            manager.add_local_repo(url)
+
+
+def _populate_parser(cli_plugins, parser):
+    verbs_parser = parser.add_subparsers(
+        dest='repoverb',
+        metavar='VERB',
+    )
+    for cli_plugin_name, plugin in cli_plugins.items():
+        plugin_parser = verbs_parser.add_parser(
+            cli_plugin_name, **plugin.init_args
+        )
+        plugin.populate_parser(plugin_parser)
+
+    return parser
+
+
+class RepoCLIPlugin(CLIPlugin):
+    def populate_parser(self, parser):
+        self.cli_plugins = lago.plugins.load_plugins('lago.plugins.repo.cli')
+        _populate_parser(self.cli_plugins, parser)
+
+    def do_run(self, args):
+        self.cli_plugins[args.repoverb].do_run(args)
+
+    @property
+    def init_args(self):
+        return {'help': 'Manage vm repositories'}

--- a/lago/repo_utils.py
+++ b/lago/repo_utils.py
@@ -1,0 +1,143 @@
+import configparser
+import re
+
+
+def generate_repo(name, url, **kwargs):
+    repo = configparser.ConfigParser()
+    repo.add_section(name)
+    repo.set(name, 'baseurl', url)
+    repo.set(name, 'name', name)
+    for k, v in kwargs.viewitems():
+        repo.set(name, k, str(v))
+    return repo
+
+
+def _filter_sections_by_pattern(config, pattern, negative=False):
+    """
+    Args:
+        config(configparser.RawConfigParser) config to filter
+        pattern(str) regex pattern
+        negative(bool) if True remove all sections that don't match the pattern
+
+    Returns:
+        (generator) which generate the filtered sections
+
+    """
+    reg = re.compile(pattern)
+    for section in config.sections():
+        m = reg.match(section)
+        if negative:
+            m = not m
+        if m:
+            yield section
+
+
+def filter_sections_by_pattern(config, pattern, negative=False):
+    if not pattern:
+        return config.sections()
+    else:
+        return _filter_sections_by_pattern(config, pattern, negative)
+
+
+def strip_excludes_from_conf(config):
+    return remove_option(config, 'exclude')
+
+
+def remove_option(config, option, pattern=None, negative=False):
+    """
+    Args:
+        config(configparser.RawConfigParser)
+        option(str)
+        pattern(str)
+        negative(bool)
+
+    Returns:
+        The modified config
+
+    """
+    for section in filter_sections_by_pattern(config, pattern, negative):
+        if config.has_option(section, option):
+            config.remove_option(section, option)
+
+    return config
+
+
+def add_option_to_sections(
+    config, option, value, pattern=None, negative=False
+):
+    for section in filter_sections_by_pattern(config, pattern, negative):
+        config.set(section, option, value)
+
+
+def collect_values(config, option, pattern=None, negative=False):
+    s = set()
+    for section in filter_sections_by_pattern(config, pattern, negative):
+        if config.has_option(section, option):
+            s.add(config.get(section, option))
+
+    return s
+
+
+def add_to_conf(base, other):
+    """
+    Add the sections from other to base.
+    If section == main, merge base and other while giving precedence
+    to options from other.
+
+    If section != main, and section is in base, replace it with the new
+    section from other.
+
+    Args:
+        other(configparser.RawConfigParser) new config
+        base(configparser.RawConfigParser) base config
+
+    Returns:
+        (configparser.RawConfigParser) The modified config
+
+    """
+    for section in other.sections():
+        if section != 'main' and base.has_section(section):
+            base.remove_section(section)
+        copy_section(other, base, section)
+
+    return base
+
+
+def copy_section(other, base, section):
+    """
+    Copy section from other to base.
+    If section already exist in base, merge
+    section from base and other while giving precedence to
+    options from other.
+
+    Args:
+        other(configparser.RawConfigParser) new config
+        base(configparser.RawConfigParser) base config
+        section(str) which section to copy
+
+    Returns:
+        None
+
+    """
+    if not base.has_section(section):
+        base.add_section(section)
+
+    for option, value in other.items(section):
+        base.set(section, option, value)
+
+
+def remove_sections_by_pattern(config, pattern, negative=False):
+    """
+    Args:
+        config(configparser.RawConfigParser) config to filter
+        pattern(str) regex pattern
+        negative(bool) if True remove all sections that don't match the pattern
+
+    Returns:
+        (configparser.RawConfigParser) The modified config
+
+    """
+    for section in filter_sections_by_pattern(config, pattern, negative):
+        config.remove_section(section)
+
+    return config

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -99,6 +99,12 @@ def invoke_in_parallel(func, *args_sequences):
     vt.join_all()
 
 
+def invoke_multiple_functions(funcs):
+    vt = VectorThread(funcs)
+    vt.start_all()
+    vt.join_all()
+
+
 _CommandStatus = collections.namedtuple(
     'CommandStatus', ('code', 'out', 'err')
 )

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -286,8 +286,14 @@ class VirtEnv(object):
             except IndexError:
                 return self.get_nets().values().pop()
 
-    def get_vms(self):
+    def get_vms(self, ):
         return self._vms.copy()
+
+    def get_vms_value(self, names=None):
+        if not names:
+            return self._vms.values()
+
+        return [self.get_vm(name) for name in names]
 
     def get_vm(self, name):
         return self._vms[name]

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ lago.plugins.cli =
     generate-config=lago.cmd:do_generate
     export=lago.cmd:do_export
     template-repo=lago_template_repo:TemplateRepoCLI
+    repo=lago.repo:RepoCLIPlugin
 
 lago.plugins.output =
     default=lago.plugins.output:DefaultOutFormatPlugin
@@ -84,3 +85,14 @@ lago.plugins.ovirt.cli =
     reposetup=ovirtlago.cmd:do_ovirt_reposetup
     runtest=ovirtlago.cmd:do_ovirt_runtest
     serve=ovirtlago.cmd:do_ovirt_serve
+
+lago.plugins.repo =
+    yum=lago.repo:Yum
+    dnf=lago.repo:Dnf
+
+lago.plugins.repo.cli =
+    inject=lago.repo:do_inject
+    add=lago.repo:do_add
+    inject-local-repo=lago.repo:do_inject_local_repo
+    add-local-repo=lago.repo:do_add_local_repo
+


### PR DESCRIPTION
Lago repo management plugin
------------------------------------------
Lago repo plugin should be used for configuring the repo
config on guest vms.

The idea is to take the existing config on the guest, modyfing
it and then writing back (except for when injecting a new config).

RepoPlugin is an object that warps a vm object.

Classes which derived from RepoPlugin should contain the specific
implementaion, according to the distro which installed on the guest.

repo_utils includes helper functions for working with repo configs.

Open Tasks:
------------------

1. Add tests.
2. Add more exception handling.
3. Add more documentation.
4. Configure all the vms in parallel.
5. Export hard-coded values to the config file.

Signed-off-by: gbenhaim <galbh2@gmail.com>

closes https://github.com/lago-project/lago/issues/426