### PR TITLE
Drop check_deps function

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -856,20 +856,6 @@ def check_group_membership():
         warnings.warn('current session does not belong to lago group.')
 
 
-def check_deps():
-    try:
-        # Checks that all the deps are installed
-        pkg_resources.require("lago")
-    except pkg_resources.ContextualVersionConflict as e:
-        # Hack that allows to run stevedore without checking
-        # for it's dep. it is required for systems running stevedore 1.1.0
-        # and pbr > 1.
-        LOGGER.debug(e, exc_info=True)
-        pkgs = e[2]
-        if set(['stevedore']) != pkgs:
-            raise e
-
-
 def main():
     cli_plugins = lago.plugins.load_plugins(
         lago.plugins.PLUGIN_ENTRY_POINTS['cli']
@@ -902,7 +888,6 @@ def main():
     else:
         warnings.formatwarning = lambda message, *args, **kwargs: message
 
-    check_deps()
     check_group_membership()
 
     args.out_format = out_plugins[args.out_format]


### PR DESCRIPTION
The above function relays on an higher version of python-setuptools
which is not available in EPEL. It seems, this was added in order be
more user friendly, and verify Lago's dependencies are installed.
However, requiring a custom-built python-setuptools for el7
installations is probably less friendly.

fixes: https://github.com/lago-project/lago/issues/468
Signed-off-by: Nadav Goldin <ngoldin@redhat.com>