### PR TITLE
Generate an init file that can be used with exported images

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -313,10 +313,20 @@ def do_stop(prefix, vm_names, **kwargs):
     default='.',
     help='Dir to place the exported images in',
 )
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--init-file-name',
+    default='LagoInitFile',
+    help='The name of the exported init file',
+)
 @in_lago_prefix
 @with_logging
-def do_export(prefix, vm_names, standalone, dst_dir, compress, **kwargs):
-    prefix.export_vms(vm_names, standalone, dst_dir, compress)
+def do_export(
+    prefix, vm_names, standalone, dst_dir, compress, init_file_name,
+    out_format, **kwargs
+):
+    prefix.export_vms(
+        vm_names, standalone, dst_dir, compress, init_file_name, out_format
+    )
 
 
 @lago.plugins.cli.cli_plugin(

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -27,6 +27,7 @@ The other plugin extension point, the [VM Provider Plugin], that allows you to
 create an alternative implementation of the provisioning details for the VM,
 for example, using a remote libvirt instance or similar.
 """
+from copy import deepcopy
 import contextlib
 import functools
 import logging
@@ -363,6 +364,10 @@ class VMPlugin(plugins.Plugin):
     @property
     def disks(self):
         return self._spec['disks'][:]
+
+    @property
+    def spec(self):
+        return deepcopy(self._spec)
 
     def name(self):
         return str(self._spec['name'])

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -961,7 +961,8 @@ class Prefix(object):
                     'dev': disk['dev'],
                     'format': disk['format'],
                     'metadata': metadata,
-                    'type': disk['type']
+                    'type': disk['type'],
+                    'name': disk['name']
                 },
             )
 
@@ -1009,9 +1010,14 @@ class Prefix(object):
             self.save()
             rollback.clear()
 
-    def export_vms(self, vms_names, standalone, export_dir, compress):
-
-        self.virt_env.export_vms(vms_names, standalone, export_dir, compress)
+    def export_vms(
+        self, vms_names, standalone, export_dir, compress, init_file_name,
+        out_format
+    ):
+        self.virt_env.export_vms(
+            vms_names, standalone, export_dir, compress, init_file_name,
+            out_format
+        )
 
     def start(self, vm_names=None):
         """

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -17,6 +17,7 @@
 #
 # Refer to the README and COPYING files for full details of the license
 #
+from copy import deepcopy
 import functools
 import hashlib
 import json
@@ -25,6 +26,7 @@ import os
 import uuid
 import time
 import lxml.etree
+import yaml
 
 from . import (
     brctl,
@@ -191,7 +193,10 @@ class VirtEnv(object):
     def bootstrap(self):
         utils.invoke_in_parallel(lambda vm: vm.bootstrap(), self._vms.values())
 
-    def export_vms(self, vms_names, standalone, dst_dir, compress):
+    def export_vms(
+        self, vms_names, standalone, dst_dir, compress, init_file_name,
+        out_format
+    ):
         if not vms_names:
             vms_names = self._vms.keys()
 
@@ -218,6 +223,88 @@ class VirtEnv(object):
         with LogTask('Exporting disks to: {}'.format(dst_dir)):
             for _vm in vms:
                 _vm.export_disks(standalone, dst_dir, compress)
+
+        self.generate_init(os.path.join(dst_dir, init_file_name), out_format)
+
+    def generate_init(self, dst, out_format, filters=None):
+        """
+        Generate an init file which represents this env and can
+        be used with the images created by self.export_vms
+
+        Args:
+            dst (str): path and name of the new init file
+            out_format (plugins.output.OutFormatPlugin):
+                formatter for the output (the default is yaml)
+            filters (list): list of paths to keys that should be removed from
+                the init file
+        Returns:
+            None
+        """
+        with LogTask('Exporting init file to: {}'.format(dst)):
+            # Set the default formatter to yaml. The default formatter
+            # doesn't generate a valid init file, so it's not reasonable
+            # to use it
+            if isinstance(out_format, plugins.output.DefaultOutFormatPlugin):
+                out_format = plugins.output.YAMLOutFormatPlugin()
+
+            if not filters:
+                filters = [
+                    'domains/*/disks/*/metadata',
+                    'domains/*/metadata/deploy-scripts', 'domains/*/snapshots',
+                    'domains/*/name', 'nets/*/mapping'
+                ]
+            spec = self.get_env_spec(filters)
+
+            for _, domain in spec['domains'].viewitems():
+                for disk in domain['disks']:
+                    if disk['type'] == 'template':
+                        disk['template_type'] = 'qcow2'
+                    elif disk['type'] == 'empty':
+                        disk['type'] = 'file'
+                        disk['make_a_copy'] = 'True'
+
+                    # Insert the relative path to the exported images
+                    disk['path'] = os.path.join(
+                        '$LAGO_INITFILE_PATH', os.path.basename(disk['path'])
+                    )
+
+            with open(dst, 'wt') as f:
+                if isinstance(out_format, plugins.output.YAMLOutFormatPlugin):
+                    # Dump the yaml file without type tags
+                    # TODO: Allow passing parameters to output plugins
+                    f.write(yaml.safe_dump(spec))
+                else:
+                    f.write(out_format.format(spec))
+
+    def get_env_spec(self, filters=None):
+        """
+        Get the spec of the current env.
+        The spec will hold the info about all the domains and
+        networks associated with this env.
+
+        Args:
+            filters (list): list of paths to keys that should be removed from
+                the init file
+        Returns:
+            dict: the spec of the current env
+        """
+        spec = {
+            'domains':
+                {
+                    vm_name: vm_object.spec
+                    for vm_name, vm_object in self._vms.viewitems()
+                },
+            'nets':
+                {
+                    net_name: net_object.spec
+                    for net_name, net_object in self._nets.viewitems()
+                }
+        }
+
+        if filters:
+            utils.filter_spec(spec, filters)
+
+        return spec
 
     def start(self, vm_names=None):
         if not vm_names:
@@ -458,6 +545,10 @@ class Network(object):
     def save(self):
         with open(self._env.virt_path('net-%s' % self.name()), 'w') as f:
             utils.json_dump(self._spec, f)
+
+    @property
+    def spec(self):
+        return deepcopy(self._spec)
 
 
 class NATNetwork(Network):

--- a/tests/functional/fixtures/snapshot/1host_1disk_list
+++ b/tests/functional/fixtures/snapshot/1host_1disk_list
@@ -19,6 +19,7 @@
                     "size": 1780088832,
                     "version": "v1"
                 },
+                "name": "root", 
                 "path": "@@PREFIX_PATH@@/images/lago_functional_tests_vm01_root.qcow2",
                 "type": "template"
             }


### PR DESCRIPTION
The generated init file will represent the env and will contain
relative paths to the exported images.

Signed-off-by: gbenhaim <galbh2@gmail.com>

closes https://github.com/lago-project/lago/issues/473