### PR TITLE
Remove the whole marking of usage of templates

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -712,7 +712,6 @@ class Prefix(object):
             )
             template_store.download(template_version)
 
-        template_store.mark_used(template_version, self.paths.uuid())
         disk_metadata.update(
             template_store.get_stored_metadata(template_version, ),
         )

--- a/lago/templates.py
+++ b/lago/templates.py
@@ -26,7 +26,6 @@ import magic
 import os
 import posixpath
 import shutil
-import time
 import urllib
 import sys
 
@@ -679,28 +678,6 @@ class TemplateStore:
                 if result:
                     raise RuntimeError(result.err)
 
-            self._init_users(temp_ver)
-
-    def _init_users(self, temp_ver):
-        """
-        Initializes the user access registry
-
-        Args:
-            temp_ver (TemplateVersion): template version to update registry
-                for
-
-        Returns:
-            None
-        """
-        with open('%s.users' % self.get_path(temp_ver), 'w') as f:
-            utils.json_dump(
-                {
-                    'users': {},
-                    'last_access': int(time.time()),
-                },
-                f,
-            )
-
     def get_stored_metadata(self, temp_ver):
         """
         Retrieves the metadata for the given template version from the store
@@ -728,36 +705,3 @@ class TemplateStore:
         """
         with open(self._prefixed('%s.hash' % temp_ver.name)) as f:
             return f.read().strip()
-
-    def mark_used(self, temp_ver, key_path):
-        """
-        Adds or updates the user entry in the user access log for the given
-        template version
-
-        Args:
-            temp_ver (TemplateVersion): template version to add the entry for
-            key_path (str): Path to the prefix uuid file to set the mark for
-        """
-        dest = self.get_path(temp_ver)
-
-        with lockfile.LockFile(dest):
-            with open('%s.users' % dest) as f:
-                users = json.load(f)
-
-            updated_users = {}
-            for path, key in users['users'].items():
-                try:
-                    with open(path) as f:
-                        if key == f.read():
-                            updated_users[path] = key
-                except OSError:
-                    pass
-                except IOError:
-                    pass
-
-            with open(key_path) as f:
-                updated_users[key_path] = f.read()
-            users['users'] = updated_users
-            users['last_access'] = int(time.time())
-            with open('%s.users' % dest, 'w') as f:
-                utils.json_dump(users, f)


### PR DESCRIPTION
Not sure why it's needed and where it's used.
Doesn't seem very useful.