### PR TITLE
Adding lago shutdown

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -278,6 +278,30 @@ def do_stop(prefix, vm_names, **kwargs):
 
 
 @lago.plugins.cli.cli_plugin(
+    help='Shutdown and destroy, or reboot vms',
+    description='This command will shutdown or reboot the given vms. '
+    'Networks that will not have running vms connected to them after '
+    'running this command will be stopped as well.'
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '-r',
+    '--reboot',
+    help='If specified, reboot the requested vms',
+    action='store_true',
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    'vm_names',
+    help='Name of the vms to shutdown',
+    metavar='VM_NAME',
+    nargs='*',
+)
+@in_lago_prefix
+@with_logging
+def do_shutdown(prefix, vm_names, reboot, **kwargs):
+    prefix.shutdown(vm_names, reboot)
+
+
+@lago.plugins.cli.cli_plugin(
     help='Export virtual machine disks',
     description='This command will export the disks of the given vms. '
     'The disks of the vms will be exported to the '

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -106,6 +106,26 @@ class VMProviderPlugin(plugins.Plugin):
         pass
 
     @abstractmethod
+    def shutdown(self, *args, **kwargs):
+        """
+        Shutdown a domain
+
+        Returns:
+            None
+        """
+        pass
+
+    @abstractmethod
+    def reboot(self, *args, **kwargs):
+        """
+        Reboot a domain
+
+        Returns:
+            None
+        """
+        pass
+
+    @abstractmethod
     def defined(self, *args, **kwargs):
         """
         Return if the domain is defined (libvirt concept), currently used only
@@ -283,6 +303,18 @@ class VMPlugin(plugins.Plugin):
         Thin method that just uses the provider
         """
         return self.provider.stop(*args, **kwargs)
+
+    def shutdown(self, *args, **kwargs):
+        """
+        Thin method that just uses the provider
+        """
+        return self.provider.shutdown(*args, **kwargs)
+
+    def reboot(self, *args, **kwargs):
+        """
+        Thin method that just uses the provider
+        """
+        return self.provider.reboot(*args, **kwargs)
 
     def defined(self, *args, **kwargs):
         """

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -1043,6 +1043,19 @@ class Prefix(object):
         """
         self.virt_env.stop(vm_names=vm_names)
 
+    def shutdown(self, vm_names=None, reboot=False):
+        """
+        Shutdown this prefix
+
+        Args:
+            vm_names(list of str): List of the vms to shutdown
+            reboot(bool): If true, reboot the requested vms
+
+        Returns:
+            None
+        """
+        self.virt_env.shutdown(vm_names, reboot)
+
     def create_snapshots(self, name):
         """
         Creates one snapshot on all the domains with the given name

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -332,31 +332,92 @@ class VirtEnv(object):
                     rollback.prependDefer(vm.stop)
                 rollback.clear()
 
-    def stop(self, vm_names=None):
+    def _get_stop_shutdown_common_args(self, vm_names):
+        """
+        Get the common arguments for stop and shutdown commands
+
+        Args:
+            vm_names (list of str): The names of the requested vms
+
+        Returns
+            list of plugins.vm.VMProviderPlugin:
+                vms objects that should be stopped
+            list of virt.Network: net objects that should be stopped
+            str: log message
+
+        Raises:
+            utils.LagoUserException: If a vm name doesn't exist
+        """
+
+        vms_to_stop = self.get_vms(vm_names).values()
+
         if not vm_names:
-            log_msg = 'Stop prefix'
-            vms = self._vms.values()
+            log_msg = '{} prefix'
             nets = self._nets.values()
         else:
-            log_msg = 'Stop specified VMs'
-            vms = [self._vms[vm_name] for vm_name in vm_names]
-            stoppable_nets = set()
-            for vm in vms:
-                stoppable_nets = stoppable_nets.union(vm.nets())
-            for vm in self._vms.values():
-                if not vm.defined() or vm.name() in vm_names:
-                    continue
-                for net in vm.nets():
-                    stoppable_nets.discard(net)
-            nets = [self._nets[net] for net in stoppable_nets]
+            log_msg = '{} specified VMs'
+            nets = self._get_unused_nets(vms_to_stop)
 
-        with LogTask(log_msg):
+        return vms_to_stop, nets, log_msg
+
+    def _get_unused_nets(self, vms_to_stop):
+        """
+        Return a list of nets that used only by the vms in vms_to_stop
+
+        Args:
+            vms_to_stop (list of str): The names of the requested vms
+
+        Returns
+            list of virt.Network: net objects that used only by
+                vms in vms_to_stop
+
+        Raises:
+            utils.LagoUserException: If a vm name doesn't exist
+        """
+
+        vm_names = [vm.name() for vm in vms_to_stop]
+        unused_nets = set()
+
+        for vm in vms_to_stop:
+            unused_nets = unused_nets.union(vm.nets())
+        for vm in self._vms.values():
+            if not vm.defined() or vm.name() in vm_names:
+                continue
+            for net in vm.nets():
+                unused_nets.discard(net)
+        nets = [self._nets[net] for net in unused_nets]
+
+        return nets
+
+    def stop(self, vm_names=None):
+
+        vms, nets, log_msg = self._get_stop_shutdown_common_args(vm_names)
+
+        with LogTask(log_msg.format('Stop')):
             with LogTask('Stop vms'):
                 for vm in vms:
                     vm.stop()
             with LogTask('Stop nets'):
                 for net in nets:
                     net.stop()
+
+    def shutdown(self, vm_names, reboot=False):
+
+        vms, nets, log_msg = self._get_stop_shutdown_common_args(vm_names)
+
+        if reboot:
+            with LogTask(log_msg.format('Reboot')):
+                with LogTask('Reboot vms'):
+                    for vm in vms:
+                        vm.reboot()
+        else:
+            with LogTask(log_msg.format('Shutdown')):
+                with LogTask('Shutdown vms'):
+                    for vm in vms:
+                        vm.shutdown()
+                with LogTask('Stop nets'):
+                    for net in nets:
+                        net.stop()
 
     def get_nets(self):
         return self._nets.copy()
@@ -373,8 +434,39 @@ class VirtEnv(object):
             except IndexError:
                 return self.get_nets().values().pop()
 
-    def get_vms(self):
-        return self._vms.copy()
+    def get_vms(self, vm_names=None):
+        """
+        Returns the vm objects associated with vm_names
+        if vm_names is None, return all the vms in the prefix
+
+        Args:
+            vm_names (list of str): The names of the requested vms
+
+        Returns
+            dict: Which contains the requested vm objects indexed by name
+
+        Raises:
+            utils.LagoUserException: If a vm name doesn't exist
+        """
+        if not vm_names:
+            return self._vms.copy()
+
+        missing_vms = []
+        vms = {}
+        for name in vm_names:
+            try:
+                vms[name] = self._vms[name]
+            except KeyError:
+                # TODO: add resolver by suffix
+                missing_vms.append(name)
+
+        if missing_vms:
+            raise utils.LagoUserException(
+                'The following vms do not exist: \n{}'.
+                format('\n'.join(missing_vms))
+            )
+
+        return vms
 
     def get_vm(self, name):
         return self._vms[name]

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ lago.plugins.cli =
     stop=lago.cmd:do_stop
     generate-config=lago.cmd:do_generate
     export=lago.cmd:do_export
+    shutdown=lago.cmd:do_shutdown
     template-repo=lago_template_repo:TemplateRepoCLI
 
 lago.plugins.output =


### PR DESCRIPTION
1. Adding lago shutdown - gracefully shutdown / reboot vm.
2. If acpi is enabled in the vm, use libvirt function, otherwise
   try to run the command using ssh.
3. Change VirtEnv.get_vms to support filtering by name.

Signed-off-by: gbenhaim <galbh2@gmail.com>

closes https://github.com/lago-project/lago/issues/464