### PR TITLE
Revert "spec: require paramiko >= 1.16.1-2 on el7"

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -69,7 +69,7 @@ BuildRequires: python2-configparser
 BuildRequires: python2-paramiko >= 2.1.1
 %else
 BuildRequires: python-configparser
-BuildRequires: python2-paramiko >= 1.16.1-2
+BuildRequires: python2-paramiko
 %endif
 
 %if 0%{?fedora} >= 23
@@ -105,7 +105,7 @@ Requires: python2-configparser
 Requires: python2-paramiko >= 2.1.1
 %else
 Requires: python-configparser
-Requires: python2-paramiko >= 1.16.1-2
+Requires: python2-paramiko
 %endif
 %if 0%{?rhel}
 Requires: qemu-img-rhev >= 2.1.2


### PR DESCRIPTION
This reverts commit 79249c14b6346a91764d5a532e2dd8afe5f46563.

1. CSB systems doesn't have those versions of paramiko.
2. We don't realy need a specific version of paramiko.