### PR TITLE
Let us control if DNS should be enabled in a libvirt network.

### DIFF
--- a/lago/net_nat_template.xml
+++ b/lago/net_nat_template.xml
@@ -6,7 +6,7 @@
     </nat>
   </forward>
   <bridge name='@BR_NAME@' stp='on' delay='0' />
-  <dns forwardPlainNames='yes' >
+  <dns enable='@ENABLE_DNS@' forwardPlainNames='yes'>
   </dns>
   <ip address='@GW_ADDR@' netmask='255.255.255.0' />
   <ip family='ipv6' address='fd8f:1391:3a82:@SUBNET@::1' prefix='64' />

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -650,10 +650,15 @@ class NATNetwork(Network):
 
         subnet = self.gw().split('.')[2]
         replacements = {
-            '@NAME@': self._libvirt_name(),
+            '@NAME@':
+                self._libvirt_name(),
             '@BR_NAME@': ('%s-nic' % self._libvirt_name())[:12],
-            '@GW_ADDR@': self.gw(),
-            '@SUBNET@': subnet,
+            '@GW_ADDR@':
+                self.gw(),
+            '@SUBNET@':
+                subnet,
+            '@ENABLE_DNS@':
+                'yes' if self._spec.get('enable_dns', True) else 'no',
         }
         for k, v in replacements.items():
             net_raw_xml = net_raw_xml.replace(k, v, 1)


### PR DESCRIPTION
This is a simple way to make sure we can use DHCP in multiple networks (with only one also served by DNS).