### PR TITLE
Increase shutdown timeout

### DIFF
--- a/lago/vm.py
+++ b/lago/vm.py
@@ -144,9 +144,9 @@ class LocalLibvirtVMProvider(vm.VMProviderPlugin):
         )
 
         try:
-            with utils.ExceptionTimer(timeout=15):
+            with utils.ExceptionTimer(timeout=60 * 5):
                 while self.defined():
-                    time.sleep(0.1)
+                    time.sleep(1)
         except utils.TimerException:
             raise utils.LagoUserException(
                 'Failed to shutdown vm: {}'.format(self.vm.name())


### PR DESCRIPTION
The previous timeout of 15 secondes wasn't enough
for shutting down loaded vms (such as ovirt-engine).

Signed-off-by: gbenhaim <galbh2@gmail.com>