### PR TITLE
Adding DHCP reservation to unmanaged networks

### DIFF
--- a/lago/virt.py
+++ b/lago/virt.py
@@ -701,24 +701,24 @@ class NATNetwork(Network):
                 )
             )
 
-            if self.is_management():
-                for hostname, ip4 in self._spec['mapping'].items():
-                    dhcp.append(
-                        lxml.etree.Element(
-                            'host',
-                            mac=utils.ipv4_to_mac(ip4),
-                            ip=ip4,
-                            name=hostname
-                        )
+            for hostname, ip4 in self._spec['mapping'].items():
+                dhcp.append(
+                    lxml.etree.Element(
+                        'host',
+                        mac=utils.ipv4_to_mac(ip4),
+                        ip=ip4,
+                        name=hostname
                     )
-                    dhcpv6.append(
-                        lxml.etree.Element(
-                            'host',
-                            id='0:3:0:1:' + utils.ipv4_to_mac(ip4),
-                            ip=IPV6_PREFIX + ip4,
-                            name=hostname
-                        )
+                )
+                dhcpv6.append(
+                    lxml.etree.Element(
+                        'host',
+                        id='0:3:0:1:' + utils.ipv4_to_mac(ip4),
+                        ip=IPV6_PREFIX + ip4,
+                        name=hostname
                     )
+                )
+                if self.is_management():
                     dns_host = lxml.etree.SubElement(dns, 'host', ip=ip4)
                     dns_name = lxml.etree.SubElement(dns_host, 'hostname')
                     dns_name.text = hostname


### PR DESCRIPTION
At this moment DHCP reservation is available only for networks that
were marked as management in the init file.

This patch add the option to specify reserved addresses in unmanged
networks as well.

Signed-off-by: gbenhaim <galbh2@gmail.com>