### PR TITLE
modified junit reports naming to match the standard ci convention

### DIFF
--- a/ovirtlago/__init__.py
+++ b/ovirtlago/__init__.py
@@ -174,7 +174,7 @@ class OvirtPrefix(Prefix):
             results_path = os.path.abspath(
                 os.path.join(
                     self.paths.prefix,
-                    'nosetests-%s.xml' % os.path.basename(path),
+                    '%s.junit.xml' % os.path.basename(path),
                 )
             )
             extra_args = [

--- a/tests/functional/ovirt.runtest.bats
+++ b/tests/functional/ovirt.runtest.bats
@@ -34,9 +34,9 @@ unset LAGO__START__WAIT_SUSPEND
     for testfile in "${testfiles[@]}"; do
         helpers.run_ok "$LAGOCLI" ovirt runtest "$FIXTURES/$testfile"
         helpers.contains "$output" "${testfile%.*}.test_pass"
-        helpers.is_file "$PREFIX/nosetests-$testfile.xml"
+        helpers.is_file "$PREFIX/$testfile.junit.xml"
         helpers.contains \
-            "$(cat $PREFIX/nosetests-$testfile.xml)" \
+            "$(cat $PREFIX/$testfile.junit.xml)" \
             'errors="0"'
     done
 }
@@ -52,9 +52,9 @@ unset LAGO__START__WAIT_SUSPEND
     for testfile in "${testfiles[@]}"; do
         helpers.run_nook "$LAGOCLI" ovirt runtest "$FIXTURES/$testfile"
         helpers.contains "$output" "${testfile%.*}.test_fail"
-        helpers.is_file "$PREFIX/nosetests-$testfile.xml"
+        helpers.is_file "$PREFIX/$testfile.junit.xml"
         helpers.contains \
-            "$(cat $PREFIX/nosetests-$testfile.xml)" \
+            "$(cat $PREFIX/$testfile.junit.xml)" \
             'failures="1"'
     done
 }
@@ -70,9 +70,9 @@ unset LAGO__START__WAIT_SUSPEND
     for testfile in "${testfiles[@]}"; do
         helpers.run_nook "$LAGOCLI" ovirt runtest "$FIXTURES/$testfile"
         helpers.contains "$output" "${testfile%.*}.test_error"
-        helpers.is_file "$PREFIX/nosetests-$testfile.xml"
+        helpers.is_file "$PREFIX/$testfile.junit.xml"
         helpers.contains \
-            "$(cat $PREFIX/nosetests-$testfile.xml)" \
+            "$(cat $PREFIX/$testfile.junit.xml)" \
             'errors="1"'
     done
 }


### PR DESCRIPTION
In order to support junit reports in all the projects in std ci,
we've changed the naming convension of junit reports to "*.junit.xml"