### PR TITLE
tests: add prefix and cpu tests to ovirt.runtest

### DIFF
--- a/tests/functional/fixtures/ovirt.runtest/002_testlib.py
+++ b/tests/functional/fixtures/ovirt.runtest/002_testlib.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python2
+import nose.tools as nt
+from ovirtlago import testlib
+
+
+@testlib.with_ovirt_prefix
+def test_cpu_model_host(prefix):
+    cpu_family = prefix.virt_env.get_ovirt_cpu_family()
+    nt.assert_equals(cpu_family, 'Intel Westmere Family')
+
+
+@testlib.with_ovirt_prefix
+def test_cpu_model_engine(prefix):
+    engine = prefix.virt_env.engine_vm()
+    cpu_family = prefix.virt_env.get_ovirt_cpu_family(host=engine)
+    nt.assert_equals(cpu_family, 'AMD Opteron G1')
+
+
+@testlib.with_ovirt_prefix
+def test_ssh(prefix):
+    engine = prefix.virt_env.engine_vm()
+    ret = engine.ssh(['hostname'])
+    nt.assert_equals(ret.code, 0)
+
+
+@testlib.with_ovirt_prefix
+def test_service(prefix):
+    engine = prefix.virt_env.engine_vm()
+    nt.assert_true(engine.service('sshd').alive())

--- a/tests/functional/fixtures/ovirt.runtest/suite.yaml
+++ b/tests/functional/fixtures/ovirt.runtest/suite.yaml
@@ -3,7 +3,7 @@ common-host-settings: &common-host-settings
   nics:
     - net: lago_functional_tests
   disks:
-    - template_name: fc24-base
+    - template_name: el7.3-base
       type: template
       name: root
       dev: vda
@@ -12,13 +12,13 @@ common-host-settings: &common-host-settings
 domains:
   lago_functional_tests_host:
       <<: *common-host-settings
-      metadata:
-        ovirt-role: host
+      vm-type: ovirt-host
+      cpu_model: Westmere
 
   lago_functional_tests_engine:
       <<: *common-host-settings
-      metadata:
-        ovirt-role: engine
+      vm-type: ovirt-engine
+      cpu_model: Opteron_G1
 
 nets:
   lago_functional_tests:


### PR DESCRIPTION
1. Run a few "simple" prefix API calls, as used by OST.

2. Test 'cpu_model' definition. This is not strictly related to ovirtlago
but we better do this on a standard distribution(rather than
CirrOS), so in order not to make the tests longer, it is here.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>