### PR TITLE
Move to a single DNS server per management network 

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -936,7 +936,7 @@ def main():
 
     try:
         cli_plugins[args.verb].do_run(args)
-    except utils.LagoUserException as e:
+    except utils.LagoException as e:
         LOGGER.info(e.message)
         LOGGER.debug(e)
         sys.exit(2)

--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -456,7 +456,9 @@ def do_shell(prefix, host, args=None, **kwargs):
     sys.exit(result.code)
 
 
-@lago.plugins.cli.cli_plugin(help='Open serial console to the domain', )
+@lago.plugins.cli.cli_plugin(
+    help='Open serial console to the domain',
+)
 @lago.plugins.cli.cli_plugin_add_argument(
     'host',
     help='Host to connect to',

--- a/lago/export.py
+++ b/lago/export.py
@@ -152,9 +152,8 @@ class TemplateExportManager(DiskExportManager):
     """
 
     def __init__(self, dst, disk_type, disk, do_compress, *args, **kwargs):
-        super(TemplateExportManager, self).__init__(
-            dst, disk_type, disk, do_compress
-        )
+        super(TemplateExportManager,
+              self).__init__(dst, disk_type, disk, do_compress)
         self.standalone = kwargs['standalone']
         self.src_qemu_info = utils.get_qemu_info(self.src, backing_chain=True)
 
@@ -231,9 +230,8 @@ class FileExportManager(DiskExportManager):
     """
 
     def __init__(self, dst, disk_type, disk, do_compress, *args, **kwargs):
-        super(FileExportManager, self).__init__(
-            dst, disk_type, disk, do_compress
-        )
+        super(FileExportManager,
+              self).__init__(dst, disk_type, disk, do_compress)
 
     def export(self):
         """

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -411,6 +411,14 @@ class VMPlugin(plugins.Plugin):
     def spec(self):
         return deepcopy(self._spec)
 
+    @property
+    def mgmt_name(self):
+        return self._spec.get('mgmt_net', None)
+
+    @property
+    def mgmt_net(self):
+        return self.virt_env.get_net(name=self.mgmt_name)
+
     def name(self):
         return str(self._spec['name'])
 
@@ -418,7 +426,8 @@ class VMPlugin(plugins.Plugin):
         return 'iqn.2014-07.org.lago:%s' % self.name()
 
     def ip(self):
-        return str(self.virt_env.get_net().resolve(self.name()))
+        res = self.mgmt_net.resolve(self.name())
+        return res.encode('ascii', 'ignore')
 
     def all_ips(self):
         nets = {}

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -715,8 +715,7 @@ def _resolve_service_class(class_name, service_providers):
     raise plugins.NoSuchPluginError(
         'No service provider plugin with class name %s found, loaded '
         'providers: %s' % (
-            class_name,
-            [
+            class_name, [
                 plugin.__class__.__name__
                 for plugin in service_providers.itervalues()
             ],

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -353,9 +353,7 @@ class Prefix(object):
                 if not _ip_in_subnet(net['gw'], nic['ip']):
                     raise RuntimeError(
                         "%s:nic%d's IP [%s] is outside the subnet [%s]" % (
-                            dom_name,
-                            dom_spec['nics'].index(nic),
-                            nic['ip'],
+                            dom_name, dom_spec['nics'].index(nic), nic['ip'],
                             net['gw'],
                         ),
                     )
@@ -366,11 +364,8 @@ class Prefix(object):
                         if ip == net['ip']
                     ]
                     raise RuntimeError(
-                        'IP %s was to several domains: %s %s' % (
-                            nic['ip'],
-                            dom_name,
-                            ' '.join(conflict_list),
-                        ),
+                        'IP %s was to several domains: %s %s' %
+                        (nic['ip'], dom_name, ' '.join(conflict_list), ),
                     )
 
                 self._add_nic_to_mapping(net, dom_spec, nic)
@@ -519,11 +514,7 @@ class Prefix(object):
 
     @staticmethod
     def _generate_disk_name(host_name, disk_name, disk_format):
-        return '%s_%s.%s' % (
-            host_name,
-            disk_name,
-            disk_format,
-        )
+        return '%s_%s.%s' % (host_name, disk_name, disk_format, )
 
     def _generate_disk_path(self, disk_name):
         return os.path.expandvars(self.paths.images(disk_name))
@@ -713,7 +704,9 @@ class Prefix(object):
             template_store.download(template_version)
 
         disk_metadata.update(
-            template_store.get_stored_metadata(template_version, ),
+            template_store.get_stored_metadata(
+                template_version,
+            ),
         )
         base = template_store.get_path(template_version)
         qemu_cmd = [
@@ -1333,11 +1326,8 @@ class Prefix(object):
                     LOGGER.debug('STDOUT:\n%s' % out)
                     LOGGER.error('STDERR\n%s' % err)
                     raise RuntimeError(
-                        '%s failed with status %d on %s' % (
-                            script,
-                            ret,
-                            host.name(),
-                        ),
+                        '%s failed with status %d on %s' %
+                        (script, ret, host.name(), ),
                     )
 
     @log_task('Deploy environment')

--- a/lago/providers/libvirt/network.py
+++ b/lago/providers/libvirt/network.py
@@ -119,8 +119,9 @@ class Network(object):
     def stop(self):
         if self.alive():
             with LogTask('Destroy network %s' % self.name()):
-                self.libvirt_con.networkLookupByName(self._libvirt_name(),
-                                                     ).destroy()
+                self.libvirt_con.networkLookupByName(
+                    self._libvirt_name(),
+                ).destroy()
 
     def save(self):
         with open(self._env.virt_path('net-%s' % self.name()), 'w') as f:

--- a/lago/providers/libvirt/network.py
+++ b/lago/providers/libvirt/network.py
@@ -189,24 +189,24 @@ class NATNetwork(Network):
                 )
             )
 
-            if self.is_management():
-                for hostname, ip4 in self._spec['mapping'].items():
-                    dhcp.append(
-                        ET.Element(
-                            'host',
-                            mac=utils.ipv4_to_mac(ip4),
-                            ip=ip4,
-                            name=hostname
-                        )
+            for hostname, ip4 in self._spec['mapping'].items():
+                dhcp.append(
+                    ET.Element(
+                        'host',
+                        mac=utils.ipv4_to_mac(ip4),
+                        ip=ip4,
+                        name=hostname
                     )
-                    dhcpv6.append(
-                        ET.Element(
-                            'host',
-                            id='0:3:0:1:' + utils.ipv4_to_mac(ip4),
-                            ip=IPV6_PREFIX + ip4,
-                            name=hostname
-                        )
+                )
+                dhcpv6.append(
+                    ET.Element(
+                        'host',
+                        id='0:3:0:1:' + utils.ipv4_to_mac(ip4),
+                        ip=IPV6_PREFIX + ip4,
+                        name=hostname
                     )
+                )
+                if self.is_management():
                     dns_host = ET.SubElement(dns, 'host', ip=ip4)
                     dns_name = ET.SubElement(dns_host, 'hostname')
                     dns_name.text = hostname

--- a/lago/providers/libvirt/network.py
+++ b/lago/providers/libvirt/network.py
@@ -18,13 +18,13 @@
 # Refer to the README and COPYING files for full details of the license
 #
 
+from collections import defaultdict
 import functools
 import logging
 import time
 from copy import deepcopy
 
 from lxml import etree as ET
-
 import lago.providers.libvirt.utils as libvirt_utils
 from lago import brctl, log_utils, utils
 from lago.config import config
@@ -133,38 +133,58 @@ class Network(object):
 
 
 class NATNetwork(Network):
+    def _generate_dns_forward(self, forward_ip):
+        dns = ET.Element('dns', forwardPlainNames='yes')
+        dns.append(ET.Element('forwarder', addr=forward_ip))
+        return dns
+
+    def _generate_dns_disable(self):
+        dns = ET.Element('dns', enable='no')
+        return dns
+
+    def _generate_main_dns(self, records, domain, subnet):
+        dns = ET.Element('dns', forwardPlainNames='no')
+        reverse_records = defaultdict(list)
+        ipv6_prefix = self._ipv6_prefix(subnet=subnet)
+        for hostname, ip in records.iteritems():
+            reverse_records[ip] = reverse_records[ip] + [hostname]
+        for ip, hostnames in reverse_records.iteritems():
+            record_ipv4 = ET.Element('host', ip=ip)
+            record_ipv6 = ET.Element('host', ip=ipv6_prefix + ip)
+            for hostname in sorted(hostnames):
+                host = ET.Element('hostname')
+                host.text = hostname
+                record_ipv4.append(host)
+                record_ipv6.append(deepcopy(host))
+            dns.append(record_ipv4)
+            dns.append(record_ipv6)
+
+        return dns
+
+    def _ipv6_prefix(self, subnet, const='fd8f:1391:3a82:'):
+        return '{0}{1}::'.format(const, subnet)
+
     def _libvirt_xml(self):
         net_raw_xml = libvirt_utils.get_template('net_nat_template.xml')
 
         subnet = self.gw().split('.')[2]
+        ipv6_prefix = self._ipv6_prefix(subnet=subnet)
+
         replacements = {
-            '@NAME@':
-                self._libvirt_name(),
+            '@NAME@': self._libvirt_name(),
             '@BR_NAME@': ('%s-nic' % self._libvirt_name())[:12],
-            '@GW_ADDR@':
-                self.gw(),
-            '@SUBNET@':
-                subnet,
-            '@ENABLE_DNS@':
-                'yes' if self._spec.get('enable_dns', True) else 'no',
+            '@GW_ADDR@': self.gw(),
+            '@SUBNET@': subnet
         }
         for k, v in replacements.items():
             net_raw_xml = net_raw_xml.replace(k, v, 1)
 
-        net_xml = ET.fromstring(net_raw_xml)
-        dns_domain_name = self._spec.get('dns_domain_name', None)
-        if dns_domain_name is not None:
-            domain_xml = ET.Element(
-                'domain',
-                name=dns_domain_name,
-                localOnly='yes',
-            )
-            net_xml.append(domain_xml)
+        parser = ET.XMLParser(remove_blank_text=True)
+        net_xml = ET.fromstring(net_raw_xml, parser)
+
         if 'dhcp' in self._spec:
-            IPV6_PREFIX = 'fd8f:1391:3a82:' + subnet + '::'
             ipv4 = net_xml.xpath('/network/ip')[0]
             ipv6 = net_xml.xpath('/network/ip')[1]
-            dns = net_xml.xpath('/network/dns')[0]
 
             def make_ipv4(last):
                 return '.'.join(self.gw().split('.')[:-1] + [str(last)])
@@ -184,8 +204,8 @@ class NATNetwork(Network):
             dhcpv6.append(
                 ET.Element(
                     'range',
-                    start=IPV6_PREFIX + make_ipv4(self._spec['dhcp']['start']),
-                    end=IPV6_PREFIX + make_ipv4(self._spec['dhcp']['end']),
+                    start=ipv6_prefix + make_ipv4(self._spec['dhcp']['start']),
+                    end=ipv6_prefix + make_ipv4(self._spec['dhcp']['end']),
                 )
             )
 
@@ -202,22 +222,34 @@ class NATNetwork(Network):
                     ET.Element(
                         'host',
                         id='0:3:0:1:' + utils.ipv4_to_mac(ip4),
-                        ip=IPV6_PREFIX + ip4,
+                        ip=ipv6_prefix + ip4,
                         name=hostname
                     )
                 )
-                if self.is_management():
-                    dns_host = ET.SubElement(dns, 'host', ip=ip4)
-                    dns_name = ET.SubElement(dns_host, 'hostname')
-                    dns_name.text = hostname
-                    dns6_host = ET.SubElement(
-                        dns, 'host', ip=IPV6_PREFIX + ip4
-                    )
-                    dns6_name = ET.SubElement(dns6_host, 'hostname')
-                    dns6_name.text = hostname
-                    dns.append(dns_host)
-                    dns.append(dns6_host)
 
+        if self.is_management():
+            domain_xml = ET.Element(
+                'domain', name=self._spec['dns_domain_name'], localOnly='yes'
+            )
+            net_xml.append(domain_xml)
+            net_xml.append(
+                self._generate_main_dns(
+                    self._spec['dns_records'], self._spec['dns_domain_name'],
+                    subnet
+                )
+            )
+        else:
+            if self.libvirt_con.getLibVersion() < 2002000:
+                net_xml.append(
+                    self._generate_dns_forward(self._spec['dns_forward'])
+                )
+            else:
+                net_xml.append(self._generate_dns_disable())
+
+        LOGGER.debug(
+            'Generated Network XML\n {0}'.
+            format(ET.tostring(net_xml, pretty_print=True))
+        )
         return ET.tostring(net_xml)
 
 

--- a/lago/providers/libvirt/templates/net_nat_template.xml
+++ b/lago/providers/libvirt/templates/net_nat_template.xml
@@ -6,8 +6,6 @@
     </nat>
   </forward>
   <bridge name='@BR_NAME@' stp='on' delay='0' />
-  <dns enable='@ENABLE_DNS@' forwardPlainNames='yes'>
-  </dns>
   <ip address='@GW_ADDR@' netmask='255.255.255.0' />
   <ip family='ipv6' address='fd8f:1391:3a82:@SUBNET@::1' prefix='64' />
 </network>

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -101,7 +101,9 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
         if self.defined():
             self.vm._ssh_client = None
             with LogTask('Destroying VM %s' % self.vm.name()):
-                self.libvirt_con.lookupByName(self._libvirt_name(), ).destroy()
+                self.libvirt_con.lookupByName(
+                    self._libvirt_name(),
+                ).destroy()
 
     def shutdown(self, *args, **kwargs):
         super(LocalLibvirtVMProvider, self).shutdown(*args, **kwargs)
@@ -191,8 +193,8 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
                             "/boot/grub2/grub.cfg",
                             "s/set timeout=5/set timeout=0/g"
                         ) if (
-                            self.vm.distro() == 'el7' or self.vm.distro() ==
-                            'fc24'
+                            self.vm.distro() == 'el7'
+                            or self.vm.distro() == 'fc24'
                         ) else '',
                     ] + [
                         sysprep.config_net_interface_dhcp(
@@ -341,7 +343,9 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             "console",
             self._libvirt_name(),
         ]
-        return utils.run_interactive_command(command=virsh_command, )
+        return utils.run_interactive_command(
+            command=virsh_command,
+        )
 
     @property
     def cpu_model(self):
@@ -457,9 +461,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             disk.append(serial)
 
             disk.append(
-                ET.Element(
-                    'boot', order="{}".format(disk_order + 1)
-                ),
+                ET.Element('boot', order="{}".format(disk_order + 1)),
             )
 
             disk.append(
@@ -535,8 +537,8 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             try:
                 dom.snapshotCreateXML(
                     ET.tostring(snapshot_xml),
-                    libvirt.VIR_DOMAIN_SNAPSHOT_CREATE_DISK_ONLY |
-                    libvirt.VIR_DOMAIN_SNAPSHOT_CREATE_QUIESCE,
+                    libvirt.VIR_DOMAIN_SNAPSHOT_CREATE_DISK_ONLY
+                    | libvirt.VIR_DOMAIN_SNAPSHOT_CREATE_QUIESCE,
                 )
             except libvirt.libvirtError:
                 LOGGER.exception(
@@ -552,7 +554,9 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
                 disk['path'] = xml_node.xpath('source')[0].attrib['file']
                 disk['format'] = 'qcow2'
                 snap_disk = disk.copy()
-                snap_disk['path'] = xml_node.xpath('backingStore', )[0].xpath(
+                snap_disk['path'] = xml_node.xpath(
+                    'backingStore',
+                )[0].xpath(
                     'source',
                 )[0].attrib['file']
                 snap_info.append(snap_disk)

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -398,7 +398,8 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
         for key, val in replacements.items():
             dom_raw_xml = dom_raw_xml.replace(key, str(val), 1)
 
-        dom_xml = ET.fromstring(dom_raw_xml)
+        parser = ET.XMLParser(remove_blank_text=True)
+        dom_xml = ET.fromstring(dom_raw_xml, parser)
 
         for child in self._cpu:
             dom_xml.append(child)

--- a/lago/ssh.py
+++ b/lago/ssh.py
@@ -335,7 +335,9 @@ def get_ssh_client(
                 host_name,
             )
             client = paramiko.SSHClient()
-            client.set_missing_host_key_policy(paramiko.AutoAddPolicy(), )
+            client.set_missing_host_key_policy(
+                paramiko.AutoAddPolicy(),
+            )
             try:
                 if ssh_key:
                     client.connect(

--- a/lago/sysprep.py
+++ b/lago/sysprep.py
@@ -45,45 +45,30 @@ def _upload_file(local_path, remote_path):
 
 
 def set_iscsi_initiator_name(name):
-    return (
-        '--mkdir',
-        _ISCSI_DIR,
-        '--chmod',
-        '0755:%s' % _ISCSI_DIR,
-    ) + _write_file(
-        os.path.join(_ISCSI_DIR, 'initiatorname.iscsi'),
-        'InitiatorName=%s' % name,
-    )
+    return ('--mkdir', _ISCSI_DIR, '--chmod',
+            '0755:%s' % _ISCSI_DIR, ) + _write_file(
+                os.path.join(_ISCSI_DIR, 'initiatorname.iscsi'),
+                'InitiatorName=%s' % name,
+            )  # noqa: E126
 
 
 def add_ssh_key(key, with_restorecon_fix=False):
-    extra_options = (
-        '--mkdir',
-        _DOT_SSH,
-        '--chmod',
-        '0700:%s' % _DOT_SSH,
-    ) + _upload_file(_AUTHORIZED_KEYS, key)
+    extra_options = ('--mkdir', _DOT_SSH, '--chmod', '0700:%s' %
+                     _DOT_SSH, ) + _upload_file(_AUTHORIZED_KEYS, key)
     if (not os.stat(key).st_uid == 0 or not os.stat(key).st_gid == 0):
         extra_options += (
-            '--run-command',
-            'chown root.root %s' % _AUTHORIZED_KEYS,
+            '--run-command', 'chown root.root %s' % _AUTHORIZED_KEYS,
         )
     if with_restorecon_fix:
         # Fix for fc23 not relabeling on boot
         # https://bugzilla.redhat.com/1049656
-        extra_options += (
-            '--firstboot-command',
-            'restorecon -R /root/.ssh',
-        )
+        extra_options += ('--firstboot-command', 'restorecon -R /root/.ssh', )
     return extra_options
 
 
 def set_selinux_mode(mode):
     return (
-        '--mkdir',
-        _SELINUX_CONF_DIR,
-        '--chmod',
-        '0755:%s' % _SELINUX_CONF_DIR,
+        '--mkdir', _SELINUX_CONF_DIR, '--chmod', '0755:%s' % _SELINUX_CONF_DIR,
     ) + _write_file(
         _SELINUX_CONF_PATH,
         ('SELINUX=%s\n'
@@ -93,9 +78,7 @@ def set_selinux_mode(mode):
 
 def _config_net_interface(iface, **kwargs):
     return (
-        '--mkdir',
-        '/etc/sysconfig/network-scripts',
-        '--chmod',
+        '--mkdir', '/etc/sysconfig/network-scripts', '--chmod',
         '0755:/etc/sysconfig/network-scripts',
     ) + _write_file(
         os.path.join(
@@ -119,17 +102,11 @@ def config_net_interface_dhcp(iface, hwaddr):
 
 def edit(filename, expression):
     editstr = '%s:""%s""' % (filename, expression)
-    return (
-        '--edit',
-        editstr,
-    )
+    return ('--edit', editstr, )
 
 
 def update():
-    return (
-        '--update',
-        '--network',
-    )
+    return ('--update', '--network', )
 
 
 def sysprep(disk, mods, backend='direct'):
@@ -144,9 +121,7 @@ def sysprep(disk, mods, backend='direct'):
     if ret:
         raise RuntimeError(
             'Failed to bootstrap %s\ncommand:%s\nstdout:%s\nstderr:%s' % (
-                disk,
-                ' '.join('"%s"' % elem for elem in cmd),
-                ret.out,
+                disk, ' '.join('"%s"' % elem for elem in cmd), ret.out,
                 ret.err,
             )
         )

--- a/lago/templates.py
+++ b/lago/templates.py
@@ -284,12 +284,14 @@ def find_repo_by_name(name, repo_dir=None):
     if repo_dir is None:
         repo_dir = config.get('template_repos')
 
-    ret, out, _ = utils.run_command([
-        'find',
-        repo_dir,
-        '-name',
-        '*.json',
-    ], )
+    ret, out, _ = utils.run_command(
+        [
+            'find',
+            repo_dir,
+            '-name',
+            '*.json',
+        ],
+    )
 
     repos = [
         TemplateRepository.from_url(line.strip()) for line in out.split('\n')
@@ -658,10 +660,8 @@ class TemplateStore:
             sha1 = utils.get_hash(temp_dest)
             if temp_ver.get_hash() != sha1:
                 raise RuntimeError(
-                    'Image %s does not match the expected hash %s' % (
-                        temp_ver.name,
-                        sha1.hexdigest(),
-                    )
+                    'Image %s does not match the expected hash %s' %
+                    (temp_ver.name, sha1.hexdigest(), )
                 )
 
             with open('%s.hash' % dest, 'w') as f:

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -149,9 +149,8 @@ def _run_command(
         uuid = uuid_m.uuid4()
 
     if constants.LIBEXEC_DIR not in os.environ['PATH'].split(':'):
-        os.environ['PATH'] = '%s:%s' % (
-            constants.LIBEXEC_DIR, os.environ['PATH']
-        )
+        os.environ['PATH'
+                   ] = '%s:%s' % (constants.LIBEXEC_DIR, os.environ['PATH'])
 
     if input_data and not stdin:
         kwargs['stdin'] = subprocess.PIPE
@@ -554,8 +553,8 @@ def _add_subparser_to_cp(cp, section, actions, incl_unset):
     cp.add_section(section)
     print_actions = (
         action for action in actions
-        if (action.default and action.default != '==SUPPRESS=='
-            ) or (action.default is None and incl_unset)
+        if (action.default and action.default != '==SUPPRESS==') or
+        (action.default is None and incl_unset)
     )
     for action in print_actions:
         var = str(action.dest)
@@ -755,8 +754,9 @@ def filter_spec(spec, paths, wildcard='*', separator='/'):
                 except TypeError:
                     raise LagoUserException(
                         'Malformed path "{{path}}", can not get '
-                        'by key from type {spec_type}'.
-                        format(spec_type=type(spec))
+                        'by key from type {spec_type}'.format(
+                            spec_type=type(spec)
+                        )
                     )
 
     for path in paths:

--- a/lago_template_repo/__init__.py
+++ b/lago_template_repo/__init__.py
@@ -77,14 +77,14 @@ ARGUMENTS[Verbs.ADD] = (
 )  # yapf: disable
 
 ARGUMENTS[Verbs.UPDATE] = (
-    'Update the saved repositories (to origin/master).',
-    (),
-    do_update,
+    'Update the saved repositories (to origin/master).', (), do_update,
 )
 
 
 class TemplateRepoCLI(CLIPlugin):
-    init_args = {'help': 'Utility for system testing template management', }
+    init_args = {
+        'help': 'Utility for system testing template management',
+    }
 
     def populate_parser(self, parser):
         verbs = parser.add_subparsers(dest='tplverb', metavar='VERB')

--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -307,7 +307,9 @@ def _populate_parser(cli_plugins, parser):
 
 
 class OvirtCLI(CLIPlugin):
-    init_args = {'help': 'oVirt related actions', }
+    init_args = {
+        'help': 'oVirt related actions',
+    }
 
     def populate_parser(self, parser):
         self.cli_plugins = lago.plugins.load_plugins('lago.plugins.ovirt.cli')

--- a/ovirtlago/virt.py
+++ b/ovirtlago/virt.py
@@ -278,8 +278,9 @@ class EngineVM(lago.vm.DefaultVM):
             self.copy_to(config, 'engine-answer-file')
 
         result = self.interactive_ssh(
-            ['engine-setup', ] +
-            (config and ['--config-append=engine-answer-file'] or []),
+            [
+                'engine-setup',
+            ] + (config and ['--config-append=engine-answer-file'] or []),
         )
         if result.code != 0:
             raise RuntimeError('Failed to setup the engine')
@@ -303,9 +304,7 @@ class EngineVM(lago.vm.DefaultVM):
 
         for id in ids:
             testlib.assert_true_within(
-                functools.partial(
-                    _vm_is_up, id=id
-                ), timeout=5 * 60
+                functools.partial(_vm_is_up, id=id), timeout=5 * 60
             )
 
     def stop_all_vms(self):
@@ -323,9 +322,7 @@ class EngineVM(lago.vm.DefaultVM):
 
         for id in ids:
             testlib.assert_true_within(
-                functools.partial(
-                    _vm_is_down, id=id
-                ), timeout=5 * 60
+                functools.partial(_vm_is_down, id=id), timeout=5 * 60
             )
 
     @require_sdk(version='4')
@@ -402,9 +399,7 @@ class EngineVM(lago.vm.DefaultVM):
                 return all(sd.status == status for sd in sds.list())
 
             testlib.assert_true_within(
-                functools.partial(
-                    _sds_state, dc_id=dc.id
-                ), timeout=5 * 60
+                functools.partial(_sds_state, dc_id=dc.id), timeout=5 * 60
             )
 
     @require_sdk(version='4')
@@ -422,7 +417,9 @@ class EngineVM(lago.vm.DefaultVM):
 class HostVM(lago.vm.DefaultVM):
     def _artifact_paths(self):
         inherited_artifacts = super(HostVM, self)._artifact_paths()
-        return set(inherited_artifacts + ['/var/log', ])
+        return set(inherited_artifacts + [
+            '/var/log',
+        ])
 
 
 class HEHostVM(HostVM):

--- a/scripts/version_manager.py
+++ b/scripts/version_manager.py
@@ -79,8 +79,8 @@ def get_tags(repo):
     return {
         commit: os.path.basename(tag_ref)
         for tag_ref, commit in repo.get_refs().items()
-        if tag_ref.startswith('refs/tags/') and
-        VALID_TAG.match(tag_ref[len('refs/tags/'):])
+        if tag_ref.startswith('refs/tags/')
+        and VALID_TAG.match(tag_ref[len('refs/tags/'):])
     }
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,8 @@ def get_version(project_dir=os.curdir):
                     version = line.split(' ', 1)[-1]
 
     elif os.path.exists(version_manager):
-        version = check_output([version_manager, project_dir, 'version']
-                               ).strip()
+        version = check_output([version_manager, project_dir,
+                                'version']).strip()
 
     if version is None:
         raise RuntimeError('Failed to get package version')

--- a/tests/functional/fixtures/start/expected_up_status
+++ b/tests/functional/fixtures/start/expected_up_status
@@ -2,7 +2,7 @@
     Base directory: @@PREFIX_PATH@@
     [Networks]:
         [lft_net1]:
-            management: False
+            management: True
             status: up
     UUID: @@UUID@@
     [VMs]:

--- a/tests/unit/lago/providers/libvirt/test_cpu.py
+++ b/tests/unit/lago/providers/libvirt/test_cpu.py
@@ -37,9 +37,7 @@ class TestCPU(XmlTestCase):
                                    <model>{model}</model>
                                    <vendor>{vendor}</vendor>
                              </cpu>
-                             """.format(
-                arch=arch, model=model, vendor=vendor
-            )
+                             """.format(arch=arch, model=model, vendor=vendor)
         )
 
     def test_generate_topology(self):
@@ -98,11 +96,9 @@ class TestCPU(XmlTestCase):
         empty_cpu = cpu.CPU(spec={}, host_cpu=None)
         self.assertXmlEquivalentOutputs(
             ET.tostring(
-                empty_cpu.generate_exact(
-                    model=model, vcpu_num=vcpu, host_cpu=host
-                )
-            ),
-            _xml
+                empty_cpu.
+                generate_exact(model=model, vcpu_num=vcpu, host_cpu=host)
+            ), _xml
         )
 
     def test_generate_exact_intel_novmx(self, vcpu=2, model='Penryn'):
@@ -127,11 +123,9 @@ class TestCPU(XmlTestCase):
         empty_cpu = cpu.CPU(spec={}, host_cpu=None)
         self.assertXmlEquivalentOutputs(
             ET.tostring(
-                empty_cpu.generate_exact(
-                    model=model, vcpu_num=vcpu, host_cpu=host
-                )
-            ),
-            _xml
+                empty_cpu.
+                generate_exact(model=model, vcpu_num=vcpu, host_cpu=host)
+            ), _xml
         )
 
     def test_generate_exact_vendor_mismatch(self, vcpu=2, model='Opteron_G2'):
@@ -156,11 +150,9 @@ class TestCPU(XmlTestCase):
         empty_cpu = cpu.CPU(spec={}, host_cpu=None)
         self.assertXmlEquivalentOutputs(
             ET.tostring(
-                empty_cpu.generate_exact(
-                    model=model, vcpu_num=vcpu, host_cpu=host
-                )
-            ),
-            _xml
+                empty_cpu.
+                generate_exact(model=model, vcpu_num=vcpu, host_cpu=host)
+            ), _xml
         )
 
     def test_generate_exact_unknown_vendor(self, vcpu=2, model='Westmere'):
@@ -185,11 +177,9 @@ class TestCPU(XmlTestCase):
         empty_cpu = cpu.CPU(spec={}, host_cpu=None)
         self.assertXmlEquivalentOutputs(
             ET.tostring(
-                empty_cpu.generate_exact(
-                    model=model, vcpu_num=vcpu, host_cpu=host
-                )
-            ),
-            _xml
+                empty_cpu.
+                generate_exact(model=model, vcpu_num=vcpu, host_cpu=host)
+            ), _xml
         )
 
     def test_init_default(self):

--- a/tests/unit/lago/test_prefix.py
+++ b/tests/unit/lago/test_prefix.py
@@ -1,9 +1,30 @@
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
+
 import os
 
 import pytest
 
 import lago
 from lago import prefix
+from lago.utils import LagoInitException
 
 
 class PathsMock(object):
@@ -51,3 +72,200 @@ class TestPrefixPathResolution(object):
         subsub_dir = sub_dir.mkdir('subsubdir')
         result = prefix.Prefix.resolve_prefix_path(str(subsub_dir))
         assert result == os.path.abspath(str(local_prefix))
+
+
+@pytest.fixture
+def empty_prefix():
+    return prefix.Prefix(prefix='')
+
+
+class TestPrefixNetworkInitalization(object):
+    @pytest.fixture()
+    def default_mgmt(self):
+        return {'management': True, 'dns_domain_name': 'lago.local'}
+
+    @pytest.mark.parametrize(
+        ('conf'), [
+            {
+                'nets': {
+                    'net-1': {}
+                }
+            },
+            {
+                'nets': {
+                    'net-1': {
+                        'management': True
+                    }
+                }
+            },
+            {
+                'nets':
+                    {
+                        'net-1':
+                            {
+                                'management': True,
+                                'dns_domain_name': 'lago.local'
+                            }
+                    }
+            },
+        ]
+    )
+    def test_select_mgmt_networks_single_network(
+        self, empty_prefix, default_mgmt, conf
+    ):
+        mgmts = empty_prefix._select_mgmt_networks(conf)
+        expected = {'nets': {'net-1': default_mgmt}}
+        assert conf == expected
+        assert mgmts == ['net-1']
+
+    @pytest.mark.parametrize(
+        ('conf'), [
+            {
+                'nets':
+                    {
+                        'net-1': {},
+                        'net-2': {},
+                        'mgmt_net': {
+                            'management': True
+                        },
+                    }
+            },
+        ]
+    )
+    def test_select_mgmt_networks_one_mgmt(
+        self, empty_prefix, default_mgmt, conf
+    ):
+        mgmts = empty_prefix._select_mgmt_networks(conf)
+        expected = {
+            'nets': {
+                'net-1': {},
+                'net-2': {},
+                'mgmt_net': default_mgmt
+            }
+        }
+        assert conf == expected
+        assert mgmts == ['mgmt_net']
+
+    @pytest.mark.parametrize(
+        ('conf'), [{
+            'nets': {
+                'net-3': {},
+                'net-2': {},
+                'net-1': {}
+            }
+        }]
+    )
+    def test_select_mgmt_networks_no_mgmt_defined(
+        self, empty_prefix, default_mgmt, conf
+    ):
+        mgmts = empty_prefix._select_mgmt_networks(conf)
+        expected = {'nets': {'net-1': default_mgmt, 'net-2': {}, 'net-3': {}}}
+        assert conf == expected
+        assert mgmts == ['net-1']
+
+    @pytest.mark.parametrize(
+        'conf,err_msg',
+        [
+            (
+                {
+                    'domains': {
+                        'vm-01': {
+                            'nics': [{
+                                'net': 'does_not_exist'
+                            }]
+                        }
+                    },
+                    'nets': {
+                        'mgmt': {}
+                    }
+                },
+                ('Unrecognized NIC: does_not_exist, configured for VM: vm-01')
+            ),
+            (
+                {
+                    'nets':
+                        {
+                            'net-1': {
+                                'dns_domain_name': 'lago.local'
+                            },
+                            'net-2': {
+                                'dns_domain_name': 'something'
+                            }
+                        }
+                }, (
+                    'Networks: net-2,net-1, misconfigured, they are not '
+                    'marked as management, but have DNS attributes. DNS is '
+                    'supported only in management networks.'
+                )
+            ),
+            (
+                {
+                    'domains':
+                        {
+                            'vm-01': {
+                                'nics': [{
+                                    'net': 'none-mgmt'
+                                }]
+                            },
+                            'vm-02':
+                                {
+                                    'nics':
+                                        [
+                                            {
+                                                'net': 'mgmt'
+                                            }, {
+                                                'net': 'none-mgmt2'
+                                            }
+                                        ]
+                                }
+                        },
+                    'nets':
+                        {
+                            'mgmt': {
+                                'management': True
+                            },
+                            'none-mgmt': {},
+                            'none-mgmt2': {},
+                        }
+                }, (
+                    'VM vm-01 has no management network, please connect it to '
+                    'one.'
+                )
+            ),
+            (
+                {
+                    'domains':
+                        {
+                            'vm-01':
+                                {
+                                    'nics':
+                                        [{
+                                            'net': 'mgmt-1'
+                                        }, {
+                                            'net': 'mgmt-2'
+                                        }]
+                                },
+                            'vm-02': {
+                                'nics': [{
+                                    'net': 'mgmt-1'
+                                }]
+                            }  # noqa: E123
+                        },
+                    'nets':
+                        {
+                            'mgmt-1': {
+                                'management': True
+                            },
+                            'mgmt-2': {
+                                'management': True
+                            }
+                        }
+                },
+                'VM vm-01 has more than one management network'
+            )
+        ]
+    )
+    def test_validate_netconfig(self, empty_prefix, conf, err_msg):
+        with pytest.raises(LagoInitException, message=err_msg) as exc_info:
+            empty_prefix._validate_netconfig(conf)
+        exc_info.match(err_msg)

--- a/tests/unit/lago/test_workdir.py
+++ b/tests/unit/lago/test_workdir.py
@@ -313,12 +313,10 @@ class TestWorkdir(object):
         mock_workdir,
         monkeypatch,
     ):
-        (
-            mock_workdir,
-            mock_walk,
-            mock_islink,
-            mock_readlink,
-        ) = self._prepare_load_positive_run(tmpdir, mock_workdir, monkeypatch)
+        (mock_workdir, mock_walk, mock_islink,
+         mock_readlink, ) = self._prepare_load_positive_run(
+             tmpdir, mock_workdir, monkeypatch
+         )  # noqa: E121
 
         assert mock_workdir.load() is None
         assert mock_workdir.current == 'another'
@@ -332,12 +330,10 @@ class TestWorkdir(object):
         mock_workdir,
         monkeypatch,
     ):
-        (
-            mock_workdir,
-            mock_walk,
-            mock_islink,
-            mock_readlink,
-        ) = self._prepare_load_positive_run(tmpdir, mock_workdir, monkeypatch)
+        (mock_workdir, mock_walk, mock_islink,
+         mock_readlink) = self._prepare_load_positive_run(
+             tmpdir, mock_workdir, monkeypatch
+         )  # noqa: E121
 
         assert mock_workdir.load() is None
         assert (
@@ -654,18 +650,12 @@ class TestWorkdir(object):
     @pytest.mark.parametrize(
         'to_destroy',
         (
-            None,
-            [],
-            ['ni!'],
-            ['nini!', 'ninini!'],
+            None, [], ['ni!'], ['nini!', 'ninini!'],
             ['ni!', 'nini!', 'ninini!'],
         ),
         ids=(
-            'None as prefixes',
-            'empty list as prefixes',
-            'one prefix',
-            'many prefixes',
-            'all prefixes',
+            'None as prefixes', 'empty list as prefixes', 'one prefix',
+            'many prefixes', 'all prefixes',
         ),
     )
     def test_destroy(
@@ -708,46 +698,21 @@ class TestWorkdir(object):
     @pytest.mark.parametrize(
         'workdir_parent,params,should_be_found',
         (
-            (
-                os.curdir,
-                {
-                    'start_path': 'auto'
-                },
-                True,
-            ),
-            (
-                os.curdir,
-                {},
-                True,
-            ),
-            (
-                '/one/two',
-                {
-                    'start_path': '/one/two/three'
-                },
-                True,
-            ),
-            (
-                '/one',
-                {
-                    'start_path': '/one/two/three'
-                },
-                True,
-            ),
-            (
-                'shrubbery',
-                {
-                    'start_path': '/one/two/three'
-                },
-                False,
-            ),
+            (os.curdir, {
+                'start_path': 'auto'
+            }, True, ), (os.curdir, {}, True, ),
+            ('/one/two', {
+                'start_path': '/one/two/three'
+            }, True, ), ('/one', {
+                'start_path': '/one/two/three'
+            }, True, ),
+            ('shrubbery', {
+                'start_path': '/one/two/three'
+            }, False, ),
         ),
         ids=(
-            'auto uses curdir',
-            'default uses curdir',
-            'recurse one level',
-            'recurse many levels',
-            'not found',
+            'auto uses curdir', 'default uses curdir', 'recurse one level',
+            'recurse many levels', 'not found',
         ),
     )
     def test_resolve_workdir_path_from_outside_of_it(
@@ -784,31 +749,14 @@ class TestWorkdir(object):
     @pytest.mark.parametrize(
         'workdir_path,params,should_be_found',
         (
-            (
-                os.curdir,
-                {
-                    'start_path': 'auto'
-                },
-                True,
-            ),
-            (
-                os.curdir,
-                {},
-                True,
-            ),
-            (
-                'shrubbery',
-                {
-                    'start_path': '/one/two/three'
-                },
-                False,
-            ),
+            (os.curdir, {
+                'start_path': 'auto'
+            }, True, ), (os.curdir, {}, True, ),
+            ('shrubbery', {
+                'start_path': '/one/two/three'
+            }, False, ),
         ),
-        ids=(
-            'auto uses curdir',
-            'default uses curdir',
-            'not found',
-        ),
+        ids=('auto uses curdir', 'default uses curdir', 'not found', ),
     )
     def test_resolve_workdir_path_from_inside_of_it(
         self,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -149,7 +149,9 @@ def test_update_root_parser(mocked_configs_path):
 @patch('lago.config._get_configs_path', return_value=['file1'])
 def test_file_shadows_cli_default(mocked_configs_path, mocked_open):
     file1 = {'lago': {'arg': 'arg_file'}}
-    mocked_open.side_effect = [_dict_to_handler(file1), ]
+    mocked_open.side_effect = [
+        _dict_to_handler(file1),
+    ]
     parser = _args_to_parser([('--arg', {'default': 'arg_default'})])
     config_load = config.ConfigLoad()
     # although awkard looking - this mimics the round-trip in the code


### PR DESCRIPTION
1. Select a network to serve as a central DNS server, by the following logic:
  - if it is the only network defined in the init file, else;
  - the only management network defined in the init file, else;
  - if there is more than one management network, use the one with DNS
    configuration in the init file; else;
  - if there is no DNS configuration, choose the first management network found.

Corner cases such as defining DNS for two different 'management'
networks are not allowed and will throw an error on 'lago init'.

2. Once the network is chosen, all DNS records will be configured in it,
all other networks will forward the requests to it.

3. Custom DNS records can also be defined in the init file, by adding
'dns_records' in the network that has DNS configuration.