### PR TITLE
Revert "docs: pin sphinx version"

### DIFF
--- a/docs/requires.txt
+++ b/docs/requires.txt
@@ -1,6 +1,5 @@
 # For the docs
-# see: https://github.com/sphinx-doc/sphinx/issues/3597
-sphinx==1.5.3
+sphinx>1.0
 nose
 dulwich
 configparser


### PR DESCRIPTION
New version was released.

This reverts commit 4d1cfc5c80081053cfe6bb6e0ffa1b4048fe4e15.