### PR TITLE
automation: bring back libguestfs debug mode

### DIFF
--- a/automation/common.sh
+++ b/automation/common.sh
@@ -14,8 +14,7 @@ set_guestfs_params() {
     # ensure KVM is enabled under mock
     ! [[ -c "/dev/kvm" ]] && mknod /dev/kvm c 10 232
 
-    # un-comment this to debug LIBGUESTFS
-    # export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
+    export LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1
 }
 
 code_changed() {


### PR DESCRIPTION
Had some unexplained errors. Was probably a mistake to remove it in the
first place.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>