### PR TITLE
Stop using sys.exc_info in LogTask

### DIFF
--- a/lago/log_utils.py
+++ b/lago/log_utils.py
@@ -24,7 +24,7 @@ import logging
 import logging.config
 import os
 import re
-import sys
+import traceback
 import datetime
 import threading
 import uuid as uuid_m
@@ -599,10 +599,12 @@ class LogTask(object):
         getattr(self.logger, self.level)(START_TASK_TRIGGER_MSG % self.header)
         return self
 
-    def __exit__(self, *args, **kwargs):
-        exc_type, _, _ = sys.exc_info()
+    def __exit__(self, exc_type, exc_val, exc_tb):
         if exc_type and self.propagate:
             end_log_task(self.header, level='error')
+            str_tb = ''.join(traceback.format_tb(exc_tb))
+            self.logger.debug(str_tb)
+            return False
         else:
             getattr(self.logger,
                     self.level)(END_TASK_TRIGGER_MSG % self.header)

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -99,6 +99,12 @@ def invoke_in_parallel(func, *args_sequences):
     vt.join_all()
 
 
+def invoke_different_funcs_in_parallel(*funcs):
+    vt = VectorThread(funcs)
+    vt.start_all()
+    vt.join_all()
+
+
 _CommandStatus = collections.namedtuple(
     'CommandStatus', ('code', 'out', 'err')
 )

--- a/tests/unit/lago/test_log_utils.py
+++ b/tests/unit/lago/test_log_utils.py
@@ -1,0 +1,41 @@
+from lago import utils
+from lago.log_utils import LogTask
+import pytest
+
+
+class LoggerMock(object):
+    def debug(self, msg):
+        print msg
+
+    def info(self, msg):
+        print msg
+
+
+class TestLogUtils(object):
+    @pytest.fixture(scope='class')
+    def logger(self):
+        return LoggerMock()
+
+    def thrower(self, logger):
+        with LogTask('I should throw the exception', logger=logger):
+            raise RuntimeError()
+
+    def catcher(self, logger):
+        with LogTask('I should catch the exception', logger=logger):
+            try:
+                raise RuntimeError()
+            except RuntimeError:
+                pass
+
+    def test_log_task(self, logger):
+        def check_raises():
+            with pytest.raises(RuntimeError):
+                self.thrower(logger)
+
+        def check_catches():
+            try:
+                self.catcher(logger)
+            except RuntimeError:
+                pytest.fail('function "catch" did not catch the exception')
+
+        utils.invoke_different_funcs_in_parallel(check_raises, check_catches)


### PR DESCRIPTION
1. sys.exc_info returns the last exception that was caught,
this can confuse LogTask and make it print messages on exceptions that
were already handled and don't interupt to the flow of lago,
(for example when waiting for ssh).
Insted we will use the default arguments which are being passed
to __exit__, and reflects the last exception that was thrown and not handled.

2. If an error occurred, print that stack trace in LogTask.

Signed-off-by: gbenhaim <galbh2@gmail.com>