### PR TITLE
ovirtlago: assert ovirt-engine and vdsmd services are running

### DIFF
--- a/ovirtlago/cmd.py
+++ b/ovirtlago/cmd.py
@@ -228,6 +228,10 @@ def do_ovirt_status(prefix, **kwargs):
 def do_ovirt_start(prefix, with_vms, **kwargs):
     with LogTask('Starting oVirt environment'):
         prefix.start()
+        with LogTask('Waiting for ovirt-engine status'):
+            prefix.virt_env.assert_engine_alive()
+        with LogTask('Waiting for vdsmd status'):
+            prefix.virt_env.assert_vdsm_alive()
         with LogTask('Activating Engine Hosts'):
             prefix.virt_env.engine_vm().start_all_hosts()
         if with_vms:

--- a/ovirtlago/utils.py
+++ b/ovirtlago/utils.py
@@ -147,3 +147,9 @@ def require_sdk(version, modules=sys.modules):
         return wrapped_func
 
     return wrap
+
+
+def partial(func, *args, **kwargs):
+    partial_func = functools.partial(func, *args, **kwargs)
+    functools.update_wrapper(partial_func, func)
+    return partial_func


### PR DESCRIPTION
In 'lago ovirt start', before making any API calls, assert that
ovirt-engine and vdsmd services report running on all hosts. Note that
the time includes the time we have to wait for the VMs to be up(and
sshd) available, and the time for the services to come up.

fixes: https://github.com/lago-project/lago/issues/508
and probably other sporadic issues.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>