### PR TITLE
Control bootstrap in the init file

### DIFF
--- a/lago/virt.py
+++ b/lago/virt.py
@@ -155,7 +155,11 @@ class VirtEnv(object):
         return self.prefix.paths.virt(*args)
 
     def bootstrap(self):
-        utils.invoke_in_parallel(lambda vm: vm.bootstrap(), self._vms.values())
+        vms = filter(
+            lambda vm: vm.spec.get('bootstrap', True), self._vms.values()
+        )
+        if vms:
+            utils.invoke_in_parallel(lambda vm: vm.bootstrap(), vms)
 
     def export_vms(
         self, vms_names, standalone, dst_dir, compress, init_file_name,


### PR DESCRIPTION
Adding the ability to specify whether to perform
bootstrap on a given domain or not.

This will be done by adding the 'bootstrap' key and
boolean value to the domain definition.

The default will be to run bootstrap.

Init switch '--skip-bootstrap' has precedence over the
configuration in the init file.

Signed-off-by: gbenhaim <galbh2@gmail.com>