### PR TITLE
 Make DNS changes introduced in 6386bc8 backward compatible

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -29,6 +29,7 @@ import urlparse
 import urllib
 import uuid
 import warnings
+import pkg_resources
 from os.path import join
 
 import xmltodict
@@ -107,7 +108,8 @@ class Prefix(object):
         self._virt_env = None
         self._metadata = None
 
-    def _get_metadata(self):
+    @property
+    def metadata(self):
         """
         Retrieve the metadata info for this prefix
 
@@ -117,11 +119,7 @@ class Prefix(object):
         if self._metadata is None:
             try:
                 with open(self.paths.metadata()) as metadata_fd:
-                    json_data = metadata_fd.read()
-                    if json_data:
-                        self._metadata = json.load(json_data)
-                    else:
-                        raise IOError()
+                    self._metadata = json.load(metadata_fd)
             except IOError:
                 self._metadata = {}
         return self._metadata
@@ -134,7 +132,7 @@ class Prefix(object):
             None
         """
         with open(self.paths.metadata(), 'w') as metadata_fd:
-            utils.json_dump(self._get_metadata(), metadata_fd)
+            utils.json_dump(self.metadata, metadata_fd)
 
     def save(self):
         """
@@ -1202,6 +1200,10 @@ class Prefix(object):
                 vm_specs=conf['domains'],
                 net_specs=conf['nets'],
             )
+
+            self._metadata = {
+                'lago_version': pkg_resources.get_distribution("lago").version,
+            }
 
             if do_bootstrap:
                 self.virt_env.bootstrap()

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -33,6 +33,7 @@ import threading
 import textwrap
 import time
 import yaml
+import pkg_resources
 from io import StringIO
 import lockfile
 import argparse
@@ -771,6 +772,24 @@ def filter_spec(spec, paths, wildcard='*', separator='/'):
         except LagoUserException as e:
             e.message = e.message.format(path=path)
             raise
+
+
+def ver_cmp(ver1, ver2):
+    """
+    Compare lago versions
+
+    Args:
+        ver1(str): version string
+        ver2(str): version string
+
+    Returns:
+        Return negative if ver1<ver2, zero if ver1==ver2, positive if
+        ver1>ver2.
+    """
+
+    return cmp(
+        pkg_resources.parse_version(ver1), pkg_resources.parse_version(ver2)
+    )
 
 
 class LagoException(Exception):

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -101,7 +101,7 @@ class VirtEnv(object):
             cls = NATNetwork
         elif net_spec['type'] == 'bridge':
             cls = BridgeNetwork
-        return cls(self, net_spec)
+        return cls(self, net_spec, compat=self.get_compat())
 
     def _create_vm(self, vm_spec):
         default_vm_type = config.get('default_vm_type')

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -511,3 +511,10 @@ class VirtEnv(object):
             snapshots[vm_name] = vm._spec['snapshots']
 
         return snapshots
+
+    def get_compat(self):
+        """Get compatibility level for this environment - which is the Lago
+        version used to create this environment """
+        # Prior to version 0.37.0, the version which the environment was
+        # initialized in was not saved, so we default to 0.36.
+        return self.prefix.metadata.get('lago_version', '0.36.0')


### PR DESCRIPTION
Commit 6386bc8 relays on DNS records stored in the Prefix metadata.
This commit ensures that environments which were initialized prior
to that commit, will work as before.