### PR TITLE
Use a seperate template for el6

### DIFF
--- a/lago/providers/libvirt/templates/dom_template-el6.xml
+++ b/lago/providers/libvirt/templates/dom_template-el6.xml
@@ -1,0 +1,46 @@
+<domain type='kvm'>
+    <name>@NAME@</name>
+    <memory unit='MiB'>@MEM_SIZE@</memory>
+    <iothreads>1</iothreads>
+    <os>
+      <type arch='x86_64' machine='pc'>hvm</type>
+      <bootmenu enable='no'/>
+    </os>
+    <features>
+      <acpi/>
+      <apic/>
+      <pae/>
+      <vmport state='off'/>
+    </features>
+    <devices>
+      <emulator>@QEMU_KVM@</emulator>
+      <memballoon model='none'/>
+      <controller type='usb' model='none'>
+      </controller>
+      <disk type='file' device='disk'>
+        <driver name='qemu' type='qcow2'/>
+        <source file='DISK_PATH'/>
+        <target dev='DISK_DEV' bus='virtio'/>
+      </disk>
+      <channel type='unix'>
+        <source mode='bind'/>
+        <target type='virtio' name='org.qemu.guest_agent.0'/>
+      </channel>
+      <rng model='virtio'>
+        <backend model='random'>/dev/random</backend>
+        <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
+      </rng>
+      <console type='pty'>
+        <target type='virtio' port='0'/>
+      </console>
+      <video>
+        <model type='cirrus' vram='16384' heads='1'/>
+        <alias name='video0'/>
+        <address type='pci' domain='0x0000' bus='0x00' slot='0x02' function='0x0'/>
+      </video>
+    </devices>
+    <clock offset='utc'>
+      <timer name='kvmclock'>
+      </timer>
+    </clock>
+</domain>

--- a/lago/providers/libvirt/templates/dom_template-el6.xml
+++ b/lago/providers/libvirt/templates/dom_template-el6.xml
@@ -26,12 +26,15 @@
         <source mode='bind'/>
         <target type='virtio' name='org.qemu.guest_agent.0'/>
       </channel>
+      <serial type='pty'>
+          <target port='0'/>
+      </serial>
       <rng model='virtio'>
         <backend model='random'>/dev/random</backend>
         <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
       </rng>
       <console type='pty'>
-        <target type='virtio' port='0'/>
+        <target type='serial' port='0'/>
       </console>
       <video>
         <model type='cirrus' vram='16384' heads='1'/>

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -368,11 +368,18 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
         """
         return self._cpu.vendor
 
+    def _load_domain_xml(self):
+        if self.vm.distro() == 'el6':
+            dom_raw_xml = libvirt_utils.get_template('dom_template-el6.xml')
+        else:
+            dom_raw_xml = libvirt_utils.get_template('dom_template.xml')
+        return dom_raw_xml
+
     def _libvirt_name(self):
         return self.vm.virt_env.prefixed_name(self.vm.name())
 
     def _libvirt_xml(self):
-        dom_raw_xml = libvirt_utils.get_template('dom_template.xml')
+        dom_raw_xml = self._load_domain_xml()
 
         qemu_kvm_path = self._caps.findtext(
             "guest[os_type='hvm']/arch[@name='x86_64']/domain[@type='kvm']"


### PR DESCRIPTION
The idea is to "freeze" the el6 template, so we won't be breaking stuff when adding new features to the "upstream" template. Specifically for now, set the console back to 'serial'.

Fixes: https://github.com/lago-project/lago/issues/504


