### PR TITLE
tests: add coverage.py report and export results XML

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,12 @@ check-local:
 	@echo "-------------------------------------------------------------"
 	@echo "-~      Running unit tests                                 --"
 	@echo "-------------------------------------------------------------"
-	PYTHONPATH=${PWD} python2 ${PYTEST} -v tests/unit
+	PYTHONPATH=${PWD} python2 ${PYTEST} --junit-xml=lago.junit.xml \
+	   --cov-report html \
+	   --cov-report term \
+	   --cov-report xml \
+	   --cov=lago \
+	   -vvv tests/unit/
 	@echo "-------------------------------------------------------------"
 	@echo "-------------------------------------------------------------"
 

--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -21,6 +21,10 @@ echo '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~'
 if code_changed; then
     run_unit_tests \
     || res=$?
+    mv "lago.junit.xml" "$EXPORTED_DIR/"
+    mv "coverage.xml" "$EXPORTED_DIR/"
+    mv "htmlcov" "$EXPORTED_DIR/htmlcov"
+
 else
     echo " No code changes, skipping static/unit tests"
 fi

--- a/automation/common.sh
+++ b/automation/common.sh
@@ -160,7 +160,6 @@ generate_html_report() {
     cat  >exported-artifacts/index.html <<EOR
     <html>
     <body>
-        <ul>
             <li>
                 <a href="docs/html/index.html">Docs page</a>
             </li>
@@ -168,8 +167,12 @@ EOR
     if code_changed; then
         cat  >>exported-artifacts/index.html <<EOR
             <li>
-                <a href="functional_tests.tap">TAP tests result</a>
+                <a href="htmlcov/index.html">coverage.py unit tests report</a>
             </li>
+            <li>
+                <a href="functional_tests.tap">Functional tests result</a>
+            </li>
+
 EOR
     fi
 

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -19,3 +19,4 @@ pyxdg
 futures
 xmlunittest
 yapf
+pytest-cov


### PR DESCRIPTION
1. Add coverage.py test results
2. Export coverage.py results and unit tests as xunit XML

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>