### PR TITLE
tests: fix ordering in TestPrefixNetworkInitalization

### DIFF
--- a/tests/unit/lago/test_prefix.py
+++ b/tests/unit/lago/test_prefix.py
@@ -193,9 +193,9 @@ class TestPrefixNetworkInitalization(object):
                             }
                         }
                 }, (
-                    'Networks: net-2,net-1, misconfigured, they are not '
-                    'marked as management, but have DNS attributes. DNS is '
-                    'supported only in management networks.'
+                    r'Networks: (net-1,net-2|net-2,net-1), misconfigured, '
+                    'they are not marked as management, but have DNS '
+                    'attributes. DNS is supported only in management networks.'
                 )
             ),
             (


### PR DESCRIPTION
Small issue.
The exception was asserted over 'net-1, net-2,' pattern, while
it could be 'net-2, net-1'. So switching to a regex instead.


Signed-off-by: Nadav Goldin <ngoldin@redhat.com>