### PR TITLE
 sdk: add logging options

### DIFF
--- a/lago/log_utils.py
+++ b/lago/log_utils.py
@@ -725,14 +725,17 @@ def setup_prefix_logging(logdir):
     file_handler = logging.FileHandler(
         filename=os.path.join(logdir, 'lago.log'),
     )
-    file_formatter = logging.Formatter(
+    file_formatter = get_default_log_formatter()
+    file_handler.setFormatter(file_formatter)
+    logging.root.addHandler(file_handler)
+    hide_paramiko_logs()
+    hide_stevedore_logs()
+
+
+def get_default_log_formatter():
+    return logging.Formatter(
         fmt=(
             '%(asctime)s::%(filename)s::%(funcName)s::%(lineno)s::'
             '%(name)s::%(levelname)s::%(message)s'
         ),
     )
-    file_handler.setLevel(logging.DEBUG)
-    file_handler.setFormatter(file_formatter)
-    logging.root.addHandler(file_handler)
-    hide_paramiko_logs()
-    hide_stevedore_logs()

--- a/lago/sdk.py
+++ b/lago/sdk.py
@@ -39,8 +39,9 @@ def init(config, workdir=None, **kwargs):
 class SDK(object):
     """
     The SDK can be initialized in 2 ways:
-    1. (Preferred) - by calling :func:`sdk.init`.
-    2. By passing already created workdir and prefix objects.
+
+        1. (Preferred) - by calling :func:`sdk.init`.
+        2. By passing already created workdir and prefix objects.
     """
 
     def __init__(self, workdir, prefix):

--- a/lago/sdk.py
+++ b/lago/sdk.py
@@ -1,12 +1,38 @@
 from __future__ import print_function
 from lago import cmd
 from lago.config import config as lago_config
+from lago.log_utils import get_default_log_formatter
 from sdk_utils import SDKWrapper
 import weakref
 import os
+import logging
 
 
-def init(config, workdir=None, **kwargs):
+def add_stream_logger(level=logging.DEBUG, name=None):
+    """
+    Add a stream logger. This can be used for printing all SDK calls to stdout
+    while working in an interactive session. Note this is a logger for the
+    entire module, which will apply to all environments started in the same
+    session. If you need a specific logger pass a ``logfile`` to
+    :func:`~sdk.init`
+
+    Args:
+        level(int): :mod:`logging` log level
+        name(str): logger name, will default to the root logger.
+
+    Returns:
+        None
+    """
+
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    handler = logging.StreamHandler()
+    handler.setFormatter(get_default_log_formatter())
+    handler.setLevel(level)
+    logger.addHandler(handler)
+
+
+def init(config, workdir=None, logfile=None, loglevel=logging.INFO, **kwargs):
     """
     Initialize the Lago environment
 
@@ -14,6 +40,8 @@ def init(config, workdir=None, **kwargs):
         config(str): Path to LagoInitFile
         workdir(str): Path to initalize the workdir, defaults to "$PWD/.lago"
         **kwargs(dict): Pass arguments to :func:`~lago.cmd.do_init`
+        logfile(str): A path to setup a log file.
+        loglevel(int): :mod:`logging` log level.
 
     Returns:
         :class:`~lago.sdk.SDK`: Initialized Lago enviornment
@@ -22,9 +50,15 @@ def init(config, workdir=None, **kwargs):
        :exc:`~lago.utils.LagoException`: If initialization failed
     """
 
-    # .. to-do:: setup logging
-    # .. to-do:: load global configuration from a file
     # .. to-do:: allow loading the env from an existing directory
+
+    logging.root.setLevel(logging.DEBUG)
+    logging.root.addHandler(logging.NullHandler())
+    if logfile:
+        fh = logging.FileHandler(logfile)
+        fh.setLevel(loglevel)
+        fh.setFormatter(get_default_log_formatter())
+        logging.root.addHandler(fh)
 
     defaults = lago_config.get_section('init')
     if workdir is None:

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -21,4 +21,5 @@ xmlunittest
 yapf
 pytest-cov
 pytest-timeout
+pytest-catchlog
 wrapt

--- a/tests/functional-sdk/conftest.py
+++ b/tests/functional-sdk/conftest.py
@@ -16,4 +16,4 @@ def global_test_results():
 @pytest.fixture(scope='module')
 def tmp_workdir(tmpdir_factory):
     env_workdir = tmpdir_factory.mktemp('env')
-    return str(env_workdir)
+    return env_workdir

--- a/tests/unit/lago/conftest.py
+++ b/tests/unit/lago/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+import mock
+import lago
+from utils import generate_workdir_props
+
+
+@pytest.fixture()
+def mock_workdir(tmpdir, **kwargs):
+    default_props = generate_workdir_props(**kwargs)
+    return mock.Mock(
+        spec_set=lago.workdir.Workdir(str(tmpdir)), **default_props
+    )
+
+
+@pytest.fixture
+def empty_prefix():
+    return lago.prefix.Prefix(prefix='')

--- a/tests/unit/lago/test_prefix.py
+++ b/tests/unit/lago/test_prefix.py
@@ -74,11 +74,6 @@ class TestPrefixPathResolution(object):
         assert result == os.path.abspath(str(local_prefix))
 
 
-@pytest.fixture
-def empty_prefix():
-    return prefix.Prefix(prefix='')
-
-
 class TestPrefixNetworkInitalization(object):
     @pytest.fixture()
     def default_mgmt(self):

--- a/tests/unit/lago/test_sdk.py
+++ b/tests/unit/lago/test_sdk.py
@@ -1,0 +1,40 @@
+import pytest
+import logging
+from lago import sdk
+
+
+class TestSDK(object):
+    @pytest.mark.parametrize('level', ['INFO', 'CRITICAL', 'DEBUG'])
+    @pytest.mark.parametrize('name', ['logger1', 'l2'])
+    @pytest.mark.parametrize('msg', ['m1', 'm2', 'a b'])
+    def test_add_stream_logger(self, caplog, level, name, msg):
+        sdk.add_stream_logger(level=level, name=name)
+        logger = logging.getLogger(name)
+        assert logger.getEffectiveLevel() == getattr(logging, level)
+        log_at_level = getattr(logger, level.lower())
+        log_at_level(msg)
+        assert caplog.record_tuples == [
+            (name, getattr(logging, level.upper()), msg),
+        ]
+
+    @pytest.mark.parametrize('level', ['INFO', 'CRITICAL', 'DEBUG'])
+    def test_init_logger(
+        self, tmpdir, monkeypatch, mock_workdir, empty_prefix, level
+    ):
+        log_path = tmpdir.mkdir('logs').join('test.log')
+        monkeypatch.setattr(
+            'lago.cmd.do_init', lambda **kwargs: (mock_workdir, empty_prefix)
+        )
+        sdk.init(
+            config=None, workdir=None, logfile=str(log_path), loglevel=level
+        )
+        handlers = [
+            h for h in logging.root.handlers
+            if isinstance(h, logging.FileHandler)
+        ]
+        assert len(handlers) == 1
+        handler = handlers.pop()
+        assert handler.stream.name == str(log_path)
+        assert handler.level == getattr(logging, level)
+
+        logging.root.removeHandler(handler)

--- a/tests/unit/lago/test_workdir.py
+++ b/tests/unit/lago/test_workdir.py
@@ -28,22 +28,7 @@ import mock
 import lago.workdir
 import lago.prefix
 from lago.utils import LagoUserException
-
-
-@pytest.fixture()
-def mock_workdir(tmpdir, **kwargs):
-    default_props = generate_workdir_props(**kwargs)
-    return mock.Mock(
-        spec_set=lago.workdir.Workdir(str(tmpdir)), **default_props
-    )
-
-
-@pytest.fixture()
-def mock_prefix(tmpdir, **kwargs):
-    if 'initialized' not in kwargs:
-        kwargs['initialized'] = lambda: True
-
-    return mock.Mock(spec_set=lago.prefix.Prefix(str(tmpdir)), **kwargs)
+from utils import generate_workdir_params
 
 
 @pytest.fixture()
@@ -55,24 +40,6 @@ def mock_patch(monkeypatch, topatch, attribute, **kwargs):
     mock_obj = mock.Mock(**kwargs)
     monkeypatch.setattr(topatch, attribute, mock_obj)
     return mock_obj
-
-
-def generate_workdir_props(**kwargs):
-    default_props = {
-        'loaded': False,
-        'path': '.',
-        'prefixes': {},
-        'current': None,
-        'prefix_class': lago.prefix.Prefix
-    }
-    default_props.update(kwargs)
-    return default_props
-
-
-def generate_workdir_params(**kwargs):
-    if 'path' not in kwargs:
-        kwargs['path'] = '.'
-        return kwargs, generate_workdir_props(**kwargs)
 
 
 class TestWorkdirLoaded(object):

--- a/tests/unit/lago/utils.py
+++ b/tests/unit/lago/utils.py
@@ -1,0 +1,19 @@
+import lago
+
+
+def generate_workdir_props(**kwargs):
+    default_props = {
+        'loaded': False,
+        'path': '.',
+        'prefixes': {},
+        'current': None,
+        'prefix_class': lago.prefix.Prefix
+    }
+    default_props.update(kwargs)
+    return default_props
+
+
+def generate_workdir_params(**kwargs):
+    if 'path' not in kwargs:
+        kwargs['path'] = '.'
+        return kwargs, generate_workdir_props(**kwargs)

--- a/tox-sdk.ini
+++ b/tox-sdk.ini
@@ -12,6 +12,7 @@ sitepackages=True
 deps = pytest
        pytest-cov
        pytest-timeout
+       pytest-catchlog
 commands =  pytest -vvv \
                 --setup-show \
                 --junit-xml=lago-sdk.junit.xml \


### PR DESCRIPTION
1. Now the 'normal' prefix/logs/lago.log works under the SDK too.

2. Added 'add_stream_logger', which allows to easily
debug interactive sessions.

3. Allow to add a per env logfile by passing a logfile parameter
to sdk.init

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>