### PR TITLE
 sysprep: support debian network scripts locations

### DIFF
--- a/lago/sysprep.py
+++ b/lago/sysprep.py
@@ -77,16 +77,13 @@ def set_selinux_mode(mode):
 
 
 def _config_net_interface(iface, path, **kwargs):
-    return ('--mkdir', path, '--chmod',
-            '0755:{0}'.format(path), ) + _write_file(
-                os.path.join(
-                    path,
-                    'ifcfg-%s' % iface,
-                ),
-                '\n'.join(
-                    ['%s="%s"' % (k.upper(), v) for k, v in kwargs.items()]
-                ),
-            )
+    cmd = ['--mkdir', path, '--chmod', '0755:{0}'.format(path)]
+    iface_path = os.path.join(path, 'ifcfg-{0}'.format(iface))
+    config = '\n'.join(
+        ['{0}={1}'.format(k.upper(), v) for k, v in kwargs.viewitems()]
+    )
+    cmd.extend(_write_file(iface_path, config))
+    return cmd
 
 
 def config_net_iface_debian(name, mac):


### PR DESCRIPTION
1. In debian, the network scripts are found in:
    ``/etc/network/interfaces``
  And per-interfaces configurations can be loaded from:
    ``/etc/network/interfaces.d/``
  In Ubuntu 16.04, the naming scheme changed, (eth -> ens), however, it
  can still be configured by updating the kernel parameters in grub, which is what 
  we'll do for now when building the images. So keeping 'eth' convention for debian. Although
  this is *probably* not the best thing to do(go backwards with the interface names),
  But changing the interfaces names in our sysprep methods would make
  the code more complex, and I rather first implement https://github.com/lago-project/lago/issues/516.
     * Note that this does not allow NetworkManager to configure the
  interfaces, however, Ubuntu 16.04 does not come with it pre-installed with it,
  and installing takes around 250MB.

2. The second commit adds Fedora 25 support, by simply disabling network scripts creation, as NetworkManager is installed and enabled by default and configures all interfaces properly.


Signed-off-by: Nadav Goldin <ngoldin@redhat.com>