### PR TITLE
sysprep: add back escaping to network setup scripts

### DIFF
--- a/lago/sysprep.py
+++ b/lago/sysprep.py
@@ -80,7 +80,7 @@ def _config_net_interface(iface, path, **kwargs):
     cmd = ['--mkdir', path, '--chmod', '0755:{0}'.format(path)]
     iface_path = os.path.join(path, 'ifcfg-{0}'.format(iface))
     config = '\n'.join(
-        ['{0}={1}'.format(k.upper(), v) for k, v in kwargs.viewitems()]
+        ['{0}="{1}"'.format(k.upper(), v) for k, v in kwargs.viewitems()]
     )
     cmd.extend(_write_file(iface_path, config))
     return cmd


### PR DESCRIPTION
Was accidentally removed in 24994fca.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>