### PR TITLE
 Move sysprep to Jinja2 templates 

### DIFF
--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -6,6 +6,7 @@ git
 grubby
 libffi-devel
 libvirt-devel
+libguestfs-devel
 libxslt-devel
 openssl-devel
 pandoc

--- a/automation/check-patch.packages.el7
+++ b/automation/check-patch.packages.el7
@@ -3,6 +3,7 @@ bats
 git
 libffi-devel
 libvirt-devel
+libguestfs-devel
 libxslt-devel
 openssl-devel
 pandoc

--- a/lago.spec.in
+++ b/lago.spec.in
@@ -64,7 +64,9 @@ BuildRequires: python-wrapt
 %if 0%{?fedora} >= 24
 BuildRequires: python2-configparser
 BuildRequires: python2-paramiko >= 2.1.1
+BuildRequires: python2-jinja2
 %else
+BuildRequires: python-jinja2
 BuildRequires: python-configparser
 BuildRequires: python2-paramiko
 %endif
@@ -98,9 +100,11 @@ Requires: python-enum
 Requires: pyxdg
 Requires: python-wrapt
 %if 0%{?fedora} >= 24
+Requires: python2-jinja2
 Requires: python2-configparser
 Requires: python2-paramiko >= 2.1.1
 %else
+Requires: python-jinja2
 Requires: python-configparser
 Requires: python2-paramiko
 %endif
@@ -121,9 +125,11 @@ Requires: sudo
 %doc AUTHORS COPYING README.rst
 %{python2_sitelib}/%{name}/*.py*
 %{python2_sitelib}/%{name}/plugins/*.py*
+%{python2_sitelib}/%{name}/templates/*.j2
 %{python2_sitelib}/%{name}/providers/*.py*
 %{python2_sitelib}/%{name}/providers/libvirt/*.py*
 %{python2_sitelib}/%{name}/providers/libvirt/templates/*.xml
+
 %{python2_sitelib}/%{name}-%{version}-py*.egg-info
 %{_bindir}/lagocli
 %{_bindir}/lago

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -187,38 +187,22 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             if self.vm._spec['disks'][0]['type'] != 'empty' and self.vm._spec[
                 'disks'
             ][0]['format'] != 'iso':
-                sysprep_cmd = [
-                    sysprep.set_hostname(self.vm.name()),
-                    sysprep.delete_file(KDUMP_SERVICE),
-                    sysprep.delete_file(POSTFIX_SERVICE),
-                    sysprep.set_root_password(self.vm.root_password()),
-                    sysprep.add_ssh_key(
-                        self.vm.virt_env.prefix.paths.ssh_id_rsa_pub(),
-                    ),
-                    sysprep.set_iscsi_initiator_name(self.vm.iscsi_name())
-                ]
+                root_disk = self.vm._spec['disks'][0]['path']
+                mappings = {
+                    'eth{0}'.format(idx): utils.ipv4_to_mac(nic['ip'])
+                    for idx, nic in enumerate(self.vm.spec['nics'])
+                }
+                public_ssh_key = self.vm.virt_env.prefix.paths.ssh_id_rsa_pub()
 
-                if self.vm.distro() in ('fc24', 'fc25', 'debian', 'el7'):
-                    path = '/boot/grub2/grub.cfg'
-                    if self.vm.distro() == 'debian':
-                        path = '/boot/grub/grub.cfg'
-                    sysprep_cmd.append(
-                        sysprep.edit(path, 's/set timeout=5/set timeout=0/s')
-                    )
-
-                # In fc25 NetworkManager configures the interfaces successfuly
-                # on boot.
-                if self.vm.distro() not in ('fc25', 'fc26'):
-                    ifaces = [
-                        ('eth{0}'.format(idx), utils.ipv4_to_mac(nic['ip']))
-                        for idx, nic in enumerate(self.vm.spec['nics'])
-                    ]
-                    sysprep_cmd.extend(
-                        sysprep.
-                        config_net_ifaces_dhcp(self.vm.distro(), ifaces)
-                    )
-
-                sysprep.sysprep(self.vm._spec['disks'][0]['path'], sysprep_cmd)
+                sysprep.sysprep(
+                    disk=root_disk,
+                    mappings=mappings,
+                    distro=self.vm.distro(),
+                    root_password=self.vm.root_password(),
+                    public_key=public_ssh_key,
+                    iscsi_name=self.vm.iscsi_name(),
+                    hostname=self.vm.name(),
+                )
 
     def state(self):
         """

--- a/lago/templates/sysprep-base.j2
+++ b/lago/templates/sysprep-base.j2
@@ -1,0 +1,12 @@
+selinux-relabel
+hostname {{ hostname }}
+root-password password:{{ root_password }}
+{% if guestfs_ver['major'] >= 1 and guestfs_ver['minor'] >= 34 %}
+ssh-inject root:file:{{public_key}}
+{% else %}
+mkdir /root/.ssh
+chmod 0700:/root/.ssh
+upload {{ public_key }}:/root/.ssh/authorized_keys
+chmod 0600:/root/.ssh/authorized_keys
+run-command chown root:root /root/.ssh/authorized_keys
+{% endif -%}

--- a/lago/templates/sysprep-debian.j2
+++ b/lago/templates/sysprep-debian.j2
@@ -1,0 +1,6 @@
+{% import 'sysprep-macros.j2' as macros %}
+{% include 'sysprep-base.j2' %}
+
+{{ macros.network_devices_debian(mappings=mappings) }}
+
+edit /boot/grub/grub.cfg:s/set timeout=5/set timeout=0/g

--- a/lago/templates/sysprep-el6.j2
+++ b/lago/templates/sysprep-el6.j2
@@ -1,0 +1,5 @@
+{% import 'sysprep-macros.j2' as macros %}
+{% include 'sysprep-base.j2' %}
+
+{{ macros.iscsi(name=iscsi_name, hostname=hostname) }}
+{{ macros.network_devices_el(mappings=mappings) }}

--- a/lago/templates/sysprep-el7.j2
+++ b/lago/templates/sysprep-el7.j2
@@ -1,0 +1,10 @@
+{% import 'sysprep-macros.j2' as macros %}
+{% include 'sysprep-base.j2' %}
+
+{{ macros.iscsi(name=iscsi_name, hostname=hostname) }}
+{{ macros.network_devices_el(mappings=mappings) }}
+
+edit /boot/grub2/grub.cfg:s/set timeout=5/set timeout=0/g
+
+delete /etc/systemd/system/multi-user.target.wants/kdump.service
+delete /etc/systemd/system/multi-user.target.wants/postfix.service

--- a/lago/templates/sysprep-fc24.j2
+++ b/lago/templates/sysprep-fc24.j2
@@ -1,0 +1,9 @@
+{% import 'sysprep-macros.j2' as macros %}
+{% include 'sysprep-base.j2' %}
+
+{{ macros.iscsi(name=iscsi_name, hostname=hostname) }}
+
+edit /boot/grub2/grub.cfg:s/set timeout=5/set timeout=0/g
+
+delete /etc/systemd/system/multi-user.target.wants/kdump.service
+delete /etc/systemd/system/multi-user.target.wants/postfix.service

--- a/lago/templates/sysprep-fc25.j2
+++ b/lago/templates/sysprep-fc25.j2
@@ -1,0 +1,1 @@
+{% include 'sysprep-fc24.j2' %}

--- a/lago/templates/sysprep-fc26.j2
+++ b/lago/templates/sysprep-fc26.j2
@@ -1,0 +1,1 @@
+{% include 'sysprep-fc24.j2' %}

--- a/lago/templates/sysprep-macros.j2
+++ b/lago/templates/sysprep-macros.j2
@@ -1,0 +1,39 @@
+{% macro iscsi(name, hostname, path='/etc/iscsi') %}
+mkdir /etc/iscsi
+chmod 0755:/etc/iscsi
+write /etc/iscsi/initiatorname.iscsi:InitiatorName={{ name }}:{{ hostname }}
+{% endmacro %}
+
+{% macro network_devices_el(mappings) %}
+mkdir /etc/sysconfig/network-scripts
+chmod 0755:/etc/sysconfig/network-scripts
+{% filter dedent %}
+{% for iface, mac in mappings.viewitems() %}
+	write /etc/sysconfig/network-scripts/ifcfg-{{iface}}:HWADDR="{{mac}}" \
+	BOOTPROTO="dhcp" \
+	ONBOOT="yes" \
+	TYPE="Ethernet" \
+	NAME="{{iface}}" \
+
+{% endfor %}
+{% endfilter %}
+{% endmacro %}
+
+{% macro network_devices_debian(mappings) %}
+mkdir /etc/network/interfaces.d
+chmod 0755:/etc/network/interfaces.d
+
+write /etc/network/interfaces:auto lo \
+iface lo inet loopback \
+source /etc/network/interfaces.d/*.cfg \
+
+{% filter dedent %}
+{% for iface, mac in mappings.viewitems() %}
+    write /etc/network/interfaces.d/ifcfg-{{ iface }}.cfg:auto {{ iface }} \
+    iface {{ iface }} inet6 auto \
+    iface {{ iface }} inet dhcp \
+        hwaddress ether {{ mac }} \
+
+{% endfor %}
+{% endfilter %}
+{% endmacro %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ enum
 pyxdg
 configparser
 wrapt
+Jinja2

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -1,7 +1,5 @@
 # https://github.com/pypa/setuptools/issues/1042
 six
-# not provided by pip
-#python-libguestfs
 enum
 dulwich
 flake8
@@ -25,3 +23,7 @@ pytest-cov
 pytest-timeout
 pytest-catchlog
 wrapt
+Jinja2
+# guestfs is not available on PyPI, however it can be installed
+# with a direct link.
+http://download.libguestfs.org/python/guestfs-1.36.4.tar.gz

--- a/tests/unit/lago/test_sysprep.py
+++ b/tests/unit/lago/test_sysprep.py
@@ -1,0 +1,73 @@
+import pytest
+from pytest import fixture
+from lago import sysprep
+import jinja2
+import os
+import mock
+import sys
+
+
+class TemplateFactory(object):
+    def __init__(self, dst):
+        self.dst = dst
+        self.loader = jinja2.FileSystemLoader(dst)
+
+    def add(self, name, content):
+        path = os.path.join(self.dst, name)
+        with open(path, 'w+') as template:
+            template.write(content)
+
+    def add_base(self, content):
+        self.add(content=content, name='sysprep-base.j2')
+
+
+@fixture
+def factory(tmpdir):
+    return TemplateFactory(dst=str(tmpdir))
+
+
+class TestSysprep(object):
+    @pytest.mark.parametrize(
+        'distro,templates,expected', [
+            ('distro_a', ['base'], 'base'),
+            ('distro_a', ['base', 'distro_a'], 'distro_a'),
+            ('distro_b', ['base', 'distro_a'], 'base')
+        ]
+    )
+    def test_render_template_loads_expected(
+        self, factory, distro, templates, expected
+    ):
+        for template in templates:
+            factory.add('sysprep-{0}.j2'.format(template), 'empty template')
+        filename = sysprep._render_template(
+            distro=distro, loader=factory.loader
+        )
+
+        with open(filename, 'r') as generated:
+            lines = [line.strip() for line in generated.readlines()]
+        assert lines[0].strip() == '# sysprep-{0}.j2'.format(expected)
+        assert lines[1].strip() == 'empty template'
+
+    def test_dedent_filter(self, factory):
+        template = '{{ var|dedent }}'
+        factory.add_base(template)
+        filename = sysprep._render_template(
+            distro='base', loader=factory.loader, var='\tremove-indent'
+        )
+
+        with open(filename, 'r') as generated:
+            lines = generated.readlines()
+        assert lines[0].strip() == '# sysprep-base.j2'
+        assert lines[1] == 'remove-indent'
+
+    def test_guestfs_version_failed_import(self):
+        with mock.patch.dict('sys.modules'):
+            del sys.modules['guestfs']
+            assert sysprep._guestfs_version(default={'no': 'no'}) == {
+                'no': 'no'
+            }
+        assert 'guestfs' in sys.modules
+
+    def test_guestfs_version_good_import(self):
+        assert 'guestfs' in sys.modules
+        assert sysprep._guestfs_version(default={'no': 'no'}) != {'no': 'no'}


### PR DESCRIPTION
Shifting the sysprep logic to Jinja2 templates, and calling 'sysprep' with the generated file. This allows splitting the logic to different distros, re-use templates where applicable and most importantly - makes it easier to maintain. 

How it works
-----------------
On bootstrap stage, we try to load ``template/sysprep-{distro}.j2`` template. If it is not available, we load ``templates/sysprep-base.j2``. Each template can include the base one(currently all do).

The structure of templates directory is:
```bash
$ tree templates
templates
├── sysprep-base.j2
├── sysprep-debian.j2
├── sysprep-el6.j2
├── sysprep-el7.j2
├── sysprep-fc24.j2
├── sysprep-fc25.j2
├── sysprep-fc26.j2
└── sysprep-macros.j2
```
Where except the distro specific templates, ``sysprep-macros.j2`` includes some useful Jinja2 macros to make the file generation easier.
So eventually in each distro it should be pretty obvious what is happening when opening the template, for example, this is the ``el7`` one:
```jinja2
{% import 'sysprep-macros.j2' as macros %}
{% include 'sysprep-base.j2' %}

{{ macros.iscsi(name=iscsi_name, hostname=hostname) }}
{{ macros.network_devices_el(mappings=mappings) }}

delete /etc/systemd/system/multi-user.target.wants/kdump.service
delete /etc/systemd/system/multi-user.target.wants/postfix.service
```

Few other stuff:
1. I dropped some commands in sysprep.py(such as --update), because we never called them, and they can be easily append to the template. 
2. Future work could include default template per distro(without version) - such as Fedora/EL/Debian.




Signed-off-by: Nadav Goldin <ngoldin@redhat.com>