### PR TITLE
templates: Use /dev/urandom for RNG

### DIFF
--- a/lago/providers/libvirt/templates/dom_template.xml
+++ b/lago/providers/libvirt/templates/dom_template.xml
@@ -27,7 +27,7 @@
         <target type='virtio' name='org.qemu.guest_agent.0'/>
       </channel>
       <rng model='virtio'>
-        <backend model='random'>/dev/random</backend>
+        <backend model='random'>/dev/urandom</backend>
         <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
       </rng>
       <console type='pty'>


### PR DESCRIPTION
The use of /dev/urandom instead of /dev/random accelerates the
ovirt-system-tests. On local verification this change saves
6 minutes of execution time for basic-suite-4.1.

Signed-off-by: Dominik Holler <dholler@redhat.com>