### PR TITLE
build: Allow to use a list of arguments

### DIFF
--- a/tests/unit/lago/test_build.py
+++ b/tests/unit/lago/test_build.py
@@ -3,8 +3,7 @@ import lago.build as build
 import pytest
 
 fixtures_normalize_options = [
-    ({}, []),
-    (
+    ({}, []), (
         OrderedDict(
             [
                 ('option0', 'arg0'),
@@ -19,8 +18,7 @@ fixtures_normalize_options = [
             '--option2',
             'arg2',
         ]
-    ),
-    (
+    ), (
         OrderedDict([
             ('a', 'arg0'),
             ('b', ''),
@@ -32,7 +30,17 @@ fixtures_normalize_options = [
             '--option2',
             'arg2',
         ]
-    ),
+    ), (
+        OrderedDict(
+            [
+                ('a', 'arg0'), ('b', ['argb0', 'argb1', 'argb2']),
+                ('empty-list', []), ('c', None)
+            ]
+        ), [
+            '-a', 'arg0', '-b', 'argb0', '-b', 'argb1', '-b', 'argb2',
+            '--empty-list', '-c'
+        ]
+    )
 ]
 
 fixtures_check_path_to_default_ssh_key = [


### PR DESCRIPTION
1. Allow specifying a list of arguments to an option of a build command.

2. Print the build command structure when running in loglevel=DEBUG.

3. Added a test for this change.

Signed-off-by: gbenhaim <galbh2@gmail.com>