### PR TITLE
Move domain templates to Jinja2

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -130,6 +130,7 @@ Requires: sudo
 %{python2_sitelib}/%{name}/providers/*.py*
 %{python2_sitelib}/%{name}/providers/libvirt/*.py*
 %{python2_sitelib}/%{name}/providers/libvirt/templates/*.xml
+%{python2_sitelib}/%{name}/providers/libvirt/templates/*.j2
 
 %{python2_sitelib}/%{name}-%{version}-py*.egg-info
 %{_bindir}/lagocli

--- a/lago/providers/libvirt/templates/dom_template-base.xml.j2
+++ b/lago/providers/libvirt/templates/dom_template-base.xml.j2
@@ -1,6 +1,6 @@
 <domain type='kvm'>
-    <name>@NAME@</name>
-    <memory unit='MiB'>@MEM_SIZE@</memory>
+    <name>{{ name }}</name>
+    <memory unit='MiB'>{{ mem_size }}</memory>
     <iothreads>1</iothreads>
     <os>
       <type arch='x86_64' machine='pc'>hvm</type>
@@ -13,7 +13,7 @@
       <vmport state='off'/>
     </features>
     <devices>
-      <emulator>@QEMU_KVM@</emulator>
+      <emulator>{{ qemu_kvm }}</emulator>
       <memballoon model='none'/>
       <controller type='usb' model='none'>
       </controller>
@@ -26,15 +26,12 @@
         <source mode='bind'/>
         <target type='virtio' name='org.qemu.guest_agent.0'/>
       </channel>
-      <serial type='pty'>
-          <target port='0'/>
-      </serial>
       <rng model='virtio'>
-        <backend model='random'>/dev/random</backend>
+        <backend model='random'>/dev/urandom</backend>
         <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
       </rng>
       <console type='pty'>
-        <target type='serial' port='0'/>
+        <target type='virtio' port='0'/>
       </console>
       <video>
         <model type='cirrus' vram='16384' heads='1'/>

--- a/lago/providers/libvirt/templates/dom_template-base.xml.j2
+++ b/lago/providers/libvirt/templates/dom_template-base.xml.j2
@@ -27,7 +27,7 @@
         <target type='virtio' name='org.qemu.guest_agent.0'/>
       </channel>
       <rng model='virtio'>
-        <backend model='random'>/dev/urandom</backend>
+        <backend model='random'>{{ '/dev/urandom' if libvirt_ver >= 2002001 else '/dev/random' }}</backend>
         <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
       </rng>
       <console type='pty'>

--- a/lago/providers/libvirt/templates/dom_template-el6.xml.j2
+++ b/lago/providers/libvirt/templates/dom_template-el6.xml.j2
@@ -1,6 +1,6 @@
 <domain type='kvm'>
-    <name>@NAME@</name>
-    <memory unit='MiB'>@MEM_SIZE@</memory>
+    <name>{{ name }}</name>
+    <memory unit='MiB'>{{ mem_size }}</memory>
     <iothreads>1</iothreads>
     <os>
       <type arch='x86_64' machine='pc'>hvm</type>
@@ -13,7 +13,7 @@
       <vmport state='off'/>
     </features>
     <devices>
-      <emulator>@QEMU_KVM@</emulator>
+     <emulator>{{ qemu_kvm }}</emulator>
       <memballoon model='none'/>
       <controller type='usb' model='none'>
       </controller>
@@ -26,12 +26,15 @@
         <source mode='bind'/>
         <target type='virtio' name='org.qemu.guest_agent.0'/>
       </channel>
+      <serial type='pty'>
+          <target port='0'/>
+      </serial>
       <rng model='virtio'>
-        <backend model='random'>/dev/urandom</backend>
+        <backend model='random'>/dev/random</backend>
         <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
       </rng>
       <console type='pty'>
-        <target type='virtio' port='0'/>
+        <target type='serial' port='0'/>
       </console>
       <video>
         <model type='cirrus' vram='16384' heads='1'/>


### PR DESCRIPTION
1. Move domain templates to Jinja2, for now only for simple replacements, so there is not a big difference
from what we had before.
2.  Use /dev/random on libvirt versions <= 2002001
A small change comparing to https://github.com/lago-project/lago/pull/554 (currently rebased on it)


fixes: https://github.com/lago-project/lago/issues/572
fixes: https://github.com/lago-project/lago/issues/516
