### PR TITLE
Refactor subnet lease

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -79,6 +79,7 @@ BuildRequires: python-dulwich
 %endif
 BuildRequires: python-flake8
 BuildRequires: git
+BuildRequires: python-netaddr
 
 
 Requires: python
@@ -98,6 +99,7 @@ Requires: python-yaml
 Requires: python-enum34
 Requires: pyxdg
 Requires: python-wrapt
+Requires: python-netaddr
 %if 0%{?fedora} >= 24
 Requires: python2-jinja2
 Requires: python2-configparser

--- a/lago/subnet_lease.py
+++ b/lago/subnet_lease.py
@@ -17,222 +17,534 @@
 #
 # Refer to the README and COPYING files for full details of the license
 #
-"""
-Module that handles the leases for the subnets of the virtual network
-interfaces.
-
-
-.. note:: Currently only /24 ranges are handled, and all of them under the
-    192.168.MIN_SUBNET to 192.168.MAX_SUBNET ranges
-
-The leases are stored under :class:`LEASE_DIR` as json files with the form::
-
-    [
-        "/path/to/prefix/uuid/file",
-        "uuid_hash",
-    ]
-
-Where the `uuid_hash` is the 32 char uuid of the prefix (the contents of the
-uuid file at the time of doing the lease)
-
-"""
 import functools
 import json
-import lockfile
 import os
+import logging
+from netaddr import IPNetwork, AddrFormatError
+from textwrap import dedent
+from lockfile.mkdirlockfile import LockFailed
 
 from .config import config
-from . import utils
+from . import utils, log_utils
 
-#: Lower range for the allowed subnets
-MIN_SUBNET = 200
-#: Upper range for the allowed subnets
-MAX_SUBNET = 209
+LOGGER = logging.getLogger(__name__)
+LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
+LOCK_NAME = 'leases'
 
 
-def is_leasable_subnet(subnet):
+class SubnetStore(object):
     """
-    Checks if a given subnet is inside the defined provisionable range
+    SubnetStore object represents a store of subnets used by lago for network
+    bridges.
 
-    Args:
-        subnet (str): Subnet or ip in dotted decimal format
+    .. note:: Currently only /24 ranges are handled, and all of them under the
+        192.168._min_third_octet to 192.168._max_third_octet ranges.
 
-    Returns:
-        bool: True if subnet is inside the range, ``False`` otherwise
-    """
-    pieces = map(int, subnet.split('.')[:-1])
-    return (192, 168, MIN_SUBNET) <= tuple(pieces) <= (192, 168, MAX_SUBNET)
+    The leases are stored under the store's directory (which is specified
+    with the `path` argument) as json files with the form::
 
+        [
+            "/path/to/prefix/uuid/file",
+            "uuid_hash",
+        ]
 
-def _validate_lease_dir_present(func):
-    """
-    Decorator that will ensure that the lease dir exists, creating it if
-    necessary
-    """
+    Where the `uuid_hash` is the 32 char uuid of the prefix (the contents of
+    the uuid file at the time of doing the lease).
 
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        lease_dir = config['lease_dir']
-        if not os.path.isdir(lease_dir):
-            os.makedirs(lease_dir)
-        return func(*args, **kwargs)
+    The helper class :class:`Lease` is used to abstract the interaction with
+    the lease files in the store (each file will be represented with a Lease
+    object).
 
-    return wrapper
+    Cleanup of stale leases is done in a lazy manner during a request for a
+    lease. The store will remove at most 1 stale lease in each request (see
+    SubnetStore._lease_valid for more info).
 
-
-def _locked(func):
-    """
-    Decorator that will make sure that you have the exclusive lock for the
-    leases
-    """
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        lease_dir = config['lease_dir']
-        lock_file = os.path.join(lease_dir, 'leases.lock')
-
-        with lockfile.LockFile(lock_file):
-            return func(*args, **kwargs)
-
-    return wrapper
-
-
-def _take_lease(path, uuid_path):
-    """
-    Persist to the given leases path the prefix uuid that's in the uuid path
-    passed
-
-    Args:
-        path (str): Path to the leases file
-        uuid_path (str): Path to the prefix uuid
-
-    Returns:
-        None
-    """
-    with open(uuid_path) as f:
-        uuid = f.read()
-    with open(path, 'w') as f:
-        utils.json_dump((uuid_path, uuid), f)
-
-
-def _lease_owned(path, current_uuid_path):
-    """
-    Checks if the given lease is owned by the prefix whose uuid is in the given
-    path
-
-    Note:
-        The prefix must be also in the same path it was when it took the lease
-
-    Args:
-        path (str): Path to the lease
-        current_uuid_path (str): Path to the uuid to check ownersip of
-
-    Returns:
-        bool: ``True`` if the given lease in owned by the prefix, ``False``
-            otherwise
-    """
-    with open(path) as f:
-        prev_uuid_path, prev_uuid = json.load(f)
-    with open(current_uuid_path) as f:
-        current_uuid = f.read()
-
-    return current_uuid_path == prev_uuid_path and prev_uuid == current_uuid
-
-
-def _lease_valid(path):
-    """
-    Checs if the given lease still has a prefix that owns it
-
-    Args:
-        path (str): Path to the lease
-
-    Returns:
-        bool: ``True`` if the uuid path in the lease still exists and is the
-            same as the one in the lease
-    """
-    with open(path) as f:
-        uuid_path, uuid = json.load(f)
-
-    if not os.path.isfile(uuid_path):
-        return False
-
-    with open(uuid_path) as f:
-        return f.read() == uuid
-
-
-@_validate_lease_dir_present
-@_locked
-def _acquire(uuid_path):
-    """
-    Lease a free network for the given uuid path
-
-    Args:
-        uuid_path (str): Path to the uuid file of a :class:`lago.Prefix`
-
-    Returns:
-        int or None: the third element of the dotted ip of the leased network
-            or ``None`` if no lease was available
-
-    .. todo::
-        Raise exception or something instead of returning None so the
-        caller can handle the failure case
+    Attributes:
+        _path (str): Path to the store, if not specified defaults to the value
+            of `lease_dir` in the config
+        _cidr (int): Number of bits dedicated for the network address.
+            Has a fixed value of 24.
+        _subnet_template (str): A template for creating ip address.
+            Has a fixed value of `192.168.{}.0`
+        _min_third_octet (int): The minimum value of the subnets' last octet.
+        _max_third_octet (int): The maximum value of the subnets' last octet.
+        _min_subnet (netaddr.IPNetwork): The lowest subnet in the range of
+            the store.
+        _max_subnet (netaddr.IPNetwork): The highest subnet in the range of
+            the store.
     """
 
-    lease_dir = config['lease_dir']
-    for index in range(MIN_SUBNET, MAX_SUBNET + 1):
-        lease_file = os.path.join(lease_dir, '%d.lease' % index)
-        if os.path.exists(lease_file):
-            if _lease_valid(lease_file):
+    def __init__(
+        self,
+        path=None,
+        min_third_octet=200,
+        max_third_octet=255,
+    ):
+
+        self._path = path or config['lease_dir']
+        self._cidr = 24
+        self._subnet_template = '{}/{}'.format('192.168.{}.0', self._cidr)
+        self._min_third_octet = min_third_octet
+        self._max_third_octet = max_third_octet
+        self._min_subnet = IPNetwork(
+            self._subnet_template.format(min_third_octet)
+        )
+        self._max_subnet = IPNetwork(
+            self._subnet_template.format(max_third_octet)
+        )
+        self._validate_lease_dir()
+
+    def _create_lock(self):
+        return utils.LockFile(
+            path=os.path.join(self.path, LOCK_NAME), timeout=5
+        )
+
+    def _validate_lease_dir(self):
+        """
+        Validate that the directory used by this store exist,
+            otherwise create it.
+        """
+        try:
+            if not os.path.isdir:
+                os.makedirs(self.path)
+        except OSError as e:
+            # errno 13 = Permission denied
+            if e.errno == 13:
+                raise LagoSubnetLeaseBadPermissionsException(self.path)
+
+    def acquire(self, uuid_path, subnet=None):
+        """
+        Lease a free subnet for the given uuid path.
+        If subnet is given, try to lease that subnet, otherwise try to lease a
+        free subnet.
+
+        Args:
+            uuid_path (str): Path to the uuid file of a :class:`lago.Prefix`
+            subnet (str): A subnet to lease.
+        Returns:
+            netaddr.IPAddress: An object which represents the subnet.
+
+        Raises:
+            LagoSubnetLeaseException:
+                1. If this store is full
+                2. If the requested subnet is already taken.
+            LagoSubnetLeaseLockException:
+                If the lock to self.path can't be acquired.
+        """
+        try:
+            with self._create_lock():
+                if subnet:
+                    LOGGER.debug('Trying to acquire subnet {}'.format(subnet))
+                    acquired_subnet = self._acquire_given_subnet(
+                        uuid_path, subnet
+                    )
+                else:
+                    LOGGER.debug('Trying to acquire a free subnet')
+                    acquired_subnet = self._acquire(uuid_path)
+
+                return acquired_subnet
+        except (utils.TimerException, LockFailed):
+            raise LagoSubnetLeaseLockException(self.path)
+
+    def _acquire(self, uuid_path):
+        """
+        Lease a free network for the given uuid path
+
+        Args:
+            uuid_path (str): Path to the uuid file of a :class:`lago.Prefix`
+
+        Returns:
+            netaddr.IPNetwork: Which represents the selected subnet
+
+        Raises:
+            LagoSubnetLeaseException: If the store is full
+        """
+        for index in range(self._min_third_octet, self._max_third_octet + 1):
+            lease = self.create_lease_object_from_idx(index)
+            if self._lease_valid(lease):
                 continue
+            self._take_lease(lease, uuid_path, safe=False)
+            return lease.to_ip_network()
+
+        raise LagoSubnetLeaseStoreFullException(self.get_allowed_range())
+
+    def _acquire_given_subnet(self, uuid_path, subnet):
+        """
+        Try to create a lease for subnet
+
+        Args:
+            uuid_path (str): Path to the uuid file of a :class:`lago.Prefix`
+            subnet (str): dotted ipv4 subnet
+                (for example ```192.168.200.0```)
+
+        Returns:
+            netaddr.IPNetwork: Which represents the selected subnet
+
+        Raises:
+            LagoSubnetLeaseException: If the requested subnet is not in the
+                range of this store or its already been taken
+        """
+        lease = self.create_lease_object_from_subnet(subnet)
+        self._take_lease(lease, uuid_path)
+
+        return lease.to_ip_network()
+
+    def _lease_valid(self, lease):
+        """
+        Check if the given lease exist and still has a prefix that owns it.
+        If the lease exist but its prefix isn't, remove the lease from this
+        store.
+
+        Args:
+            lease (lago.subnet_lease.Lease): Object representation of the
+                lease
+
+        Returns:
+            str or None: If the lease and its prefix exists, return the path
+                to the uuid of the prefix, else return None.
+        """
+        if not lease.exist:
+            return None
+
+        env = lease.has_env
+        if env:
+            return env
+        else:
+            self._release(lease)
+            return None
+
+    def _take_lease(self, lease, uuid_path, safe=True):
+        """
+        Persist the given lease to the store and make the prefix in uuid_path
+        his owner
+
+        Args:
+            lease(lago.subnet_lease.Lease): Object representation of the lease
+            uuid_path (str): Path to the prefix uuid
+            safe (bool): If true (the default), validate the the lease
+                isn't taken.
+
+        Raises:
+            LagoSubnetLeaseException: If safe == True and the lease is already
+                taken.
+        """
+        if safe:
+            lease_taken_by = self._lease_valid(lease)
+            if lease_taken_by and lease_taken_by != uuid_path:
+                raise LagoSubnetLeaseTakenException(
+                    lease.subnet, lease_taken_by
+                )
+
+        with open(uuid_path) as f:
+            uuid = f.read()
+        with open(lease.path, 'wt') as f:
+            utils.json_dump((uuid_path, uuid), f)
+
+        LOGGER.debug(
+            'Assigned subnet lease {} to {}'.format(lease.path, uuid_path)
+        )
+
+    def release(self, subnet):
+        """
+        Free the lease of the given subnet
+
+        Args:
+            subnet (str or netaddr.IPAddress): dotted ipv4 subnet in CIDR
+                notation (for example ```192.168.200.0/24```) or IPAddress
+                object.
+
+        Raises:
+            LagoSubnetLeaseException: If subnet is a str and can't be parsed
+            LagoSubnetLeaseLockException:
+                If the lock to self.path can't be acquired.
+        """
+        if isinstance(subnet, IPNetwork):
+            subnet = str(subnet)
+
+        try:
+            with self._create_lock():
+                self._release(self.create_lease_object_from_subnet(subnet))
+        except (utils.TimerException, LockFailed):
+            raise LagoSubnetLeaseLockException(self.path)
+
+    def _release(self, lease):
+        """
+        Free the given lease
+
+        Args:
+            lease (lago.subnet_lease.Lease): The lease to free
+        """
+        if lease.exist:
+            os.unlink(lease.path)
+            LOGGER.debug('Removed subnet lease {}'.format(lease.path))
+
+    def _lease_owned(self, lease, current_uuid_path):
+        """
+        Checks if the given lease is owned by the prefix whose uuid is in
+        the given path
+
+        Note:
+            The prefix must be also in the same path it was when it took the
+            lease
+
+        Args:
+            path (str): Path to the lease
+            current_uuid_path (str): Path to the uuid to check ownership of
+
+        Returns:
+            bool: ``True`` if the given lease in owned by the prefix,
+                ``False`` otherwise
+        """
+
+        prev_uuid_path, prev_uuid = lease.metadata
+
+        with open(current_uuid_path) as f:
+            current_uuid = f.read()
+
+        return \
+            current_uuid_path == prev_uuid_path and \
+            prev_uuid == current_uuid
+
+    def create_lease_object_from_idx(self, idx):
+        """
+        Create a lease from self._subnet_template and put idx as its third
+        octet.
+
+        Args:
+            idx (str): The value of the third octet
+
+        Returns:
+            Lease: Lease object which represents the requested subnet.
+
+        Raises:
+            LagoSubnetLeaseOutOfRangeException: If the resultant subnet is
+            malformed or out of the range of the store.
+        """
+
+        return self.create_lease_object_from_subnet(
+            self._subnet_template.format(idx)
+        )
+
+    def create_lease_object_from_subnet(self, subnet):
+        """
+        Create a lease from ip in a dotted decimal format,
+        (for example `192.168.200.0/24`). the _cidr will be added if not exist
+        in `subnet`.
+
+        Args:
+            subnet (str): The value of the third octet
+
+        Returns:
+            Lease: Lease object which represents the requested subnet.
+
+        Raises:
+            LagoSubnetLeaseOutOfRangeException: If the resultant subnet is
+            malformed or out of the range of the store.
+        """
+        if '/' not in subnet:
+            subnet = '{}/{}'.format(subnet, self._cidr)
+
+        try:
+            if not self.is_leasable_subnet(subnet):
+                raise LagoSubnetLeaseOutOfRangeException(
+                    subnet, self.get_allowed_range()
+                )
+        except AddrFormatError:
+            raise LagoSubnetLeaseMalformedAddrException(subnet)
+
+        return Lease(store_path=self.path, subnet=subnet)
+
+    def is_leasable_subnet(self, subnet):
+        """
+        Checks if a given subnet is inside the defined provision-able range
+
+        Args:
+            subnet (str): Ip in dotted decimal format with _cidr notation
+                (for example `192.168.200.0/24`)
+
+        Returns:
+            bool: True if subnet can be parsed into IPNetwork object and is
+                inside the range, False otherwise
+        """
+
+        return \
+            self._min_subnet <= \
+            IPNetwork(subnet) <= \
+            self._max_subnet
+
+    def get_allowed_range(self):
+        """
+        Returns:
+            str: The range of the store (with lowest and highest subnets as
+                the bounds).
+        """
+        return '{} - {}'.format(self._min_subnet, self._max_subnet)
+
+    @property
+    def path(self):
+        return self._path
+
+
+class Lease(object):
+    """
+    Lease object is an abstraction of a lease file.
+
+    Attributes:
+        _store_path (str): Path to the lease's store.
+        _subnet (str): The subnet that this lease represents
+        _path (str): The path to the lease file
+    """
+
+    def __init__(self, store_path, subnet):
+        self._store_path = store_path
+        self._subnet = subnet
+        self._path = None
+        self._realise_lease_path()
+
+    @staticmethod
+    def from_lease_filename(store_path, store_template, lease_filename):
+        third_octet = lease_filename.split('.')[0]
+        return Lease(store_path, store_template.format(third_octet))
+
+    def _realise_lease_path(self):
+        ip = self.subnet.split('/')[0]
+        idx = ip.split('.')[2]
+        self._path = os.path.join(self._store_path, '{}.lease'.format(idx))
+
+    def to_ip_network(self):
+        return IPNetwork(self.subnet)
+
+    @property
+    def valid(self):
+        if self.exist:
+            return self.has_env
+        else:
+            return False
+
+    @property
+    def metadata(self):
+        with open(self.path) as f:
+            uuid_path, uuid = json.load(f)
+
+        return uuid_path, uuid
+
+    @property
+    def has_env(self):
+        return self._has_env()
+
+    def _has_env(self, uuid_path=None, uuid=None):
+        if not (uuid_path and uuid):
+            uuid_path, uuid = self.metadata
+
+        if not os.path.isfile(uuid_path):
+            return False
+
+        with open(uuid_path, mode='rt') as f:
+            if f.read() == uuid:
+                return uuid_path
             else:
-                os.unlink(lease_file)
-        _take_lease(lease_file, uuid_path)
-        return index
-    return None
+                return False
+
+    @property
+    def exist(self):
+        return os.path.isfile(self.path)
+
+    @property
+    def path(self):
+        return self._path
+
+    @path.setter
+    def path(self, data):
+        self._path = data
+
+    @property
+    def subnet(self):
+        return self._subnet
+
+    @subnet.setter
+    def subnet(self, data):
+        self._subnet = data
+
+    def __str__(self):
+        return self.subnet
 
 
-def acquire(uuid_path):
-    """
-    Lease a free network for the given uuid path
-
-    Args:
-        uuid_path (str): Path to the uuid file of a :class:`lago.Prefix`
-
-    Returns:
-        str: the dotted ip of the gateway for the leased net
-
-    .. todo:: _aquire might return None, this will throw a TypeError
-    """
-    return '192.168.%d.1' % _acquire(uuid_path)
+class LagoSubnetLeaseException(utils.LagoException):
+    pass
 
 
-@_validate_lease_dir_present
-@_locked
-def _release(index):
-    """
-    Free the lease of the given subnet index
-
-    Args:
-        index (int): Third element of a dotted ip representation of the subnet,
-            for example, for 1.2.3.4 it would be 3
-
-    Returns:
-        None
-    """
-
-    lease_dir = config['lease_dir']
-    lease_file = os.path.join(lease_dir, '%d.lease' % index)
-    os.unlink(lease_file)
+class LagoSubnetLeaseLockException(LagoSubnetLeaseException):
+    def __init__(self, store_path):
+        super(LagoSubnetLeaseLockException, self).__init__(
+            dedent(
+                """
+                Failed to acquire a lock for store {}.
+                This failure can be caused by several reasons:
+                1. Another 'lago' environment is using the store.
+                2. A stale lock was left in the store.
+                3. You don't have R/W permissions to the store.
+                """.format(store_path)
+            )
+        )
 
 
-def release(subnet):
-    """
-    Free the lease of the given subnet
+class LagoSubnetLeaseStoreFullException(LagoSubnetLeaseException):
+    def __init__(self, store_range):
+        super(LagoSubnetLeaseStoreFullException, self).__init__(
+            dedent(
+                """
+                Can't acquire subnet from range {}
+                The store of subnets is full.
+                You can free subnets by destroying unused lago environments'
+                """.format(store_range)
+            )
+        )
 
-    Args:
-        subnet (str): dotted ip or network to free the lease of
 
-    Returns:
-        None
-    """
-    _release(int(subnet.split('.')[2]))
+class LagoSubnetLeaseTakenException(LagoSubnetLeaseException):
+    def __init__(self, required_subnet, lease_taken_by):
+        super(LagoSubnetLeaseTakenException, self).__init__(
+            dedent(
+                """
+                Can't acquire subnet {}.
+                The subnet is already taken by {}.
+                """.format(required_subnet, lease_taken_by)
+            )
+        )
+
+
+class LagoSubnetLeaseOutOfRangeException(LagoSubnetLeaseException):
+    def __init__(self, required_subnet, store_range):
+        super(LagoSubnetLeaseException, self).__init__(
+            dedent(
+                """
+                Subnet {} is not valid.
+                Subnet should be in the range {}.
+                """.format(required_subnet, store_range)
+            )
+        )
+
+
+class LagoSubnetLeaseMalformedAddrException(LagoSubnetLeaseException):
+    def __init__(self, required_subnet):
+        super(LagoSubnetLeaseException, self).__init__(
+            dedent(
+                """
+                Address {} is not a valid ip address
+                """.format(required_subnet)
+            )
+        )
+
+
+class LagoSubnetLeaseBadPermissionsException(LagoSubnetLeaseException):
+    def __init__(self, store_path):
+        super(LagoSubnetLeaseException, self).__init__(
+            dedent(
+                """
+                    Failed to get access to the store at {}.
+                    Please make sure that you have R/W permissions to this
+                    directory.
+                    """.format(store_path)
+            )
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ stevedore
 wrapt
 Jinja2
 xmltodict
+netaddr

--- a/tests/unit/lago/test_subnet_lease.py
+++ b/tests/unit/lago/test_subnet_lease.py
@@ -1,0 +1,119 @@
+from lago import subnet_lease
+import pytest
+import uuid
+import os
+import json
+import shutil
+
+
+def lease_has_valid_uuid(path_to_lease):
+    with open(path_to_lease, mode='rt') as f:
+        uuid_path, uuid_value = json.load(f)
+
+    with open(uuid_path, mode='rt') as f:
+        return uuid_value == f.read()
+
+
+class PrefixMock(object):
+    def __init__(self, path):
+        self._path = path
+        self._uuid_path = os.path.join(path, 'uuid')
+        self._validate_path()
+        self._create_uuid()
+
+    def _validate_path(self):
+        if not os.path.isdir(self.path):
+            os.makedirs(self.path)
+
+    def _create_uuid(self):
+        with open(self.uuid_path, mode='wt') as f:
+            f.write(uuid.uuid1().hex)
+
+    def remove(self):
+        shutil.rmtree(self.path)
+
+    @property
+    def path(self):
+        return self._path
+
+    @property
+    def uuid_path(self):
+        return self._uuid_path
+
+
+class TestSubnetStore(object):
+    def create_prefixes(self, path_to_workdir, num_of_prefixes=2):
+        prefixes = []
+        for i in range(0, num_of_prefixes):
+            prefix_path = os.path.join(path_to_workdir, 'prefix_{}'.format(i))
+            prefixes.append(PrefixMock(prefix_path))
+
+        return prefixes
+
+    def create_workdir_with_prefixes(self, temp_dir, num_of_prefixes=2):
+        workdir = temp_dir.mkdir('workdir')
+        return self.create_prefixes(str(workdir), num_of_prefixes)
+
+    @pytest.fixture()
+    def subnet_store(self, tmpdir):
+        subnet_store_path = tmpdir.mkdir('subnet_store')
+        return subnet_lease.SubnetStore(str(subnet_store_path))
+
+    @pytest.fixture()
+    def prefixes(self, tmpdir):
+        return self.create_workdir_with_prefixes(tmpdir)
+
+    @pytest.fixture()
+    def prefix(self, tmpdir):
+        return \
+            self.create_workdir_with_prefixes(tmpdir, num_of_prefixes=1)[0]
+
+    @pytest.mark.parametrize('subnet', [None, '192.168.210.0'])
+    def test_take_random_lease(self, subnet_store, subnet, prefix):
+        network = subnet_store.acquire(prefix.uuid_path, subnet)
+        third_octet = str(network).split('.')[2]
+        path_to_lease = os.path.join(
+            subnet_store.path, '{}.lease'.format(third_octet)
+        )
+        _, dirnames, filenames = os.walk(subnet_store.path).next()
+        assert \
+            len(dirnames) == 0 and \
+            len(filenames) == 1 and \
+            lease_has_valid_uuid(path_to_lease)
+
+    @pytest.mark.parametrize('subnet', ['127.0.0.1', '10.10.10.0'])
+    def test_fail_on_out_of_range_subnet(self, subnet_store, subnet, prefix):
+        with pytest.raises(subnet_lease.LagoSubnetLeaseOutOfRangeException):
+            subnet_store.acquire(prefix.uuid_path, subnet)
+
+    @pytest.mark.parametrize('subnet', ['256.256.256.56', '0.0.0.-1'])
+    def test_fail_on_malformed_address(self, subnet_store, subnet, prefix):
+        with pytest.raises(subnet_lease.LagoSubnetLeaseMalformedAddrException):
+            subnet_store.acquire(prefix.uuid_path, subnet)
+
+    def test_fail_on_full_store(self, subnet_store, prefix):
+        for i in xrange(
+            subnet_store._min_third_octet, subnet_store._max_third_octet + 1
+        ):
+            subnet_store.acquire(prefix.uuid_path)
+
+        with pytest.raises(subnet_lease.LagoSubnetLeaseStoreFullException):
+            subnet_store.acquire(prefix.uuid_path)
+
+    def test_recalim_lease(self, subnet_store, prefix):
+        network = subnet_store.acquire(prefix.uuid_path)
+        reclaimed_network = subnet_store.acquire(
+            prefix.uuid_path, str(network)
+        )
+
+        assert network == reclaimed_network
+
+    def test_fail_to_calim_taken_lease(self, subnet_store, prefixes):
+        with pytest.raises(subnet_lease.LagoSubnetLeaseTakenException):
+            network = subnet_store.acquire(prefixes[0].uuid_path)
+            subnet_store.acquire(prefixes[1].uuid_path, str(network))
+
+    def test_take_stale_lease(self, subnet_store, prefixes):
+        network = subnet_store.acquire(prefixes[0].uuid_path)
+        prefixes[0].remove()
+        subnet_store.acquire(prefixes[1].uuid_path, str(network))


### PR DESCRIPTION
The general idea of how to manage the store has not
changed, but the following changes were made:

1. Created a 'SubnetStore' class which represents the store.
   (it makes unit testing easier)

2. Created a 'Lease' class which represents a lease file in the store.

3. Allow requesting a specific lease from the store.

4. Increased the range of the store to 192.168.200.0-192.168.255.0

5. Use 'netaddr' to validate and represent ip addresses.

6. Improved exception handling.

7. Added unit tests.

closes https://github.com/lago-project/lago/issues/530
closes https://github.com/lago-project/lago/issues/523
closes https://github.com/lago-project/lago/issues/454


Signed-off-by: gbenhaim <galbh2@gmail.com>