### PR TITLE
Cirros0.3.5 support

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -128,6 +128,7 @@ Requires: sudo
 %{python2_sitelib}/%{name}/providers/*.py*
 %{python2_sitelib}/%{name}/providers/libvirt/*.py*
 %{python2_sitelib}/%{name}/providers/libvirt/templates/*.xml
+%{python2_sitelib}/%{name}/providers/libvirt/templates/*.j2
 
 %{python2_sitelib}/%{name}-%{version}-py*.egg-info
 %{_bindir}/lagocli

--- a/lago/providers/libvirt/templates/dom_template-base.xml.j2
+++ b/lago/providers/libvirt/templates/dom_template-base.xml.j2
@@ -1,6 +1,6 @@
 <domain type='kvm'>
-    <name>@NAME@</name>
-    <memory unit='MiB'>@MEM_SIZE@</memory>
+    <name>{{ name }}</name>
+    <memory unit='MiB'>{{ mem_size }}</memory>
     <iothreads>1</iothreads>
     <os>
       <type arch='x86_64' machine='pc'>hvm</type>
@@ -13,7 +13,7 @@
       <vmport state='off'/>
     </features>
     <devices>
-      <emulator>@QEMU_KVM@</emulator>
+      <emulator>{{ qemu_kvm }}</emulator>
       <memballoon model='none'/>
       <controller type='usb' model='none'>
       </controller>
@@ -26,15 +26,12 @@
         <source mode='bind'/>
         <target type='virtio' name='org.qemu.guest_agent.0'/>
       </channel>
-      <serial type='pty'>
-          <target port='0'/>
-      </serial>
       <rng model='virtio'>
-        <backend model='random'>/dev/random</backend>
+        <backend model='random'>/dev/urandom</backend>
         <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
       </rng>
       <console type='pty'>
-        <target type='serial' port='0'/>
+        <target type='virtio' port='0'/>
       </console>
       <video>
         <model type='cirrus' vram='16384' heads='1'/>

--- a/lago/providers/libvirt/templates/dom_template-base.xml.j2
+++ b/lago/providers/libvirt/templates/dom_template-base.xml.j2
@@ -27,7 +27,7 @@
         <target type='virtio' name='org.qemu.guest_agent.0'/>
       </channel>
       <rng model='virtio'>
-        <backend model='random'>/dev/urandom</backend>
+        <backend model='random'>{{ '/dev/urandom' if libvirt_ver >= 2002001 else '/dev/random' }}</backend>
         <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
       </rng>
       <console type='pty'>

--- a/lago/providers/libvirt/templates/dom_template-cirros0.3.5.xml.j2
+++ b/lago/providers/libvirt/templates/dom_template-cirros0.3.5.xml.j2
@@ -1,0 +1,1 @@
+dom_template-el6.xml.j2

--- a/lago/providers/libvirt/templates/dom_template-el6.xml.j2
+++ b/lago/providers/libvirt/templates/dom_template-el6.xml.j2
@@ -1,6 +1,6 @@
 <domain type='kvm'>
-    <name>@NAME@</name>
-    <memory unit='MiB'>@MEM_SIZE@</memory>
+    <name>{{ name }}</name>
+    <memory unit='MiB'>{{ mem_size }}</memory>
     <iothreads>1</iothreads>
     <os>
       <type arch='x86_64' machine='pc'>hvm</type>
@@ -13,7 +13,7 @@
       <vmport state='off'/>
     </features>
     <devices>
-      <emulator>@QEMU_KVM@</emulator>
+     <emulator>{{ qemu_kvm }}</emulator>
       <memballoon model='none'/>
       <controller type='usb' model='none'>
       </controller>
@@ -26,12 +26,15 @@
         <source mode='bind'/>
         <target type='virtio' name='org.qemu.guest_agent.0'/>
       </channel>
+      <serial type='pty'>
+          <target port='0'/>
+      </serial>
       <rng model='virtio'>
-        <backend model='random'>/dev/urandom</backend>
+        <backend model='random'>/dev/random</backend>
         <address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>
       </rng>
       <console type='pty'>
-        <target type='virtio' port='0'/>
+        <target type='serial' port='0'/>
       </console>
       <video>
         <model type='cirrus' vram='16384' heads='1'/>

--- a/lago/templates/sysprep-cirros0.3.5.j2
+++ b/lago/templates/sysprep-cirros0.3.5.j2
@@ -1,0 +1,5 @@
+{% import 'sysprep-macros.j2' as macros %}
+{% include 'sysprep-base.j2' %}
+
+{{ macros.iscsi(name=iscsi_name, hostname=hostname) }}
+{{ macros.network_devices_cirros(mappings=mappings) }}

--- a/lago/templates/sysprep-macros.j2
+++ b/lago/templates/sysprep-macros.j2
@@ -37,3 +37,15 @@ source /etc/network/interfaces.d/*.cfg \
 {% endfor %}
 {% endfilter %}
 {% endmacro %}
+
+
+{% macro network_devices_cirros(mappings) %}
+write /etc/network/interfaces:auto lo \
+iface lo inet loopback \
+{% filter dedent %}
+{%+ for iface, mac in mappings.viewitems() %}
+    auto {{ iface }} \
+    iface {{ iface }} inet dhcp \
+{% endfor %}
+{% endfilter %}
+{% endmacro %}


### PR DESCRIPTION
1. Ensure network scripts are working(on older cirros other
interfaces were just not configured properly).

2. Use same domain template as el6 with the normal serial console.


Needs https://github.com/lago-project/lago/pull/576 merged first.
