### PR TITLE
collect: search 'No such file or directory' errors properly

### DIFF
--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -259,11 +259,16 @@ class VMProviderPlugin(plugins.Plugin):
                     propagate_fail=False
                 )
             except SCPException as err:
-                err_sfx = ': No such file or directory'
-                if ignore_nopath and str.endswith(str(err.message), err_sfx):
-                    LOGGER.debug('%s: ignoring', err.message)
+                err_substr = ': No such file or directory'
+                if len(err.args) > 0 and isinstance(
+                    err.args[0], basestring
+                ) and err_substr in err.args[0]:
+                    if ignore_nopath:
+                        LOGGER.debug('%s: ignoring', err.args[0])
+                    else:
+                        raise ExtractPathNoPathError(err.args[0])
                 else:
-                    raise ExtractPathNoPathError(err.message)
+                    raise
 
 
 class VMPlugin(plugins.Plugin):


### PR DESCRIPTION
1. Search for the substring, as it might not be in the end.
2. Extract the exception message safely.
3. Re-raise the original exception on all other cases.

Fixes: https://github.com/lago-project/lago/issues/580

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>