### PR TITLE
tests: configure libguestfs parameters for sdk tests

### DIFF
--- a/tox-sdk.ini
+++ b/tox-sdk.ini
@@ -5,7 +5,12 @@ envlist = py27-sdk
 # the 'sitepackages=True' configuration. The idea is we install only
 # the dependencies for the test in venv(i.e. pytest)
 [testenv:py27-sdk]
-passenv=TEST_RESULTS PIP_CACHE_DIR LIBGUESTFS_APPEND LIBGUESTFS_CACHEDIR LIBGUESTFS_TMPDIR LIBVIRT_DEBUG LIBVIRT_LOG_OUTPUTS
+setenv =
+    LIBGUESTFS_TRACE = 1
+    LIBGUESTFS_DEBUG = 1
+    LIBGUESTFS_MEMSIZE = 2048
+
+passenv=TEST_RESULTS PIP_CACHE_DIR LIBVIRT_DEBUG LIBVIRT_LOG_OUTPUTS
 changedir=tests/functional-sdk
 deps = http://download.libguestfs.org/python/guestfs-1.36.4.tar.gz
        six


### PR DESCRIPTION
1. Always operate in debug mode
2. Increase appliance memory size per BZ 1418283

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>