### PR TITLE
Change the log level of LockFile cm

### DIFF
--- a/lago/utils.py
+++ b/lago/utils.py
@@ -388,8 +388,8 @@ class LockFile(object):
         """
         try:
             with ExceptionTimer(timeout=self.timeout):
-                with LogTask('Acquiring lock for %s' % self.path):
-                    self.lock.acquire()
+                LOGGER.debug('Acquiring lock for {}'.format(self.path))
+                self.lock.acquire()
         except TimerException:
             raise TimerException(
                 'Unable to acquire lock for %s in %s secs',


### PR DESCRIPTION
Information about locks is irrelevant to the user,
so moving it to debug level.

Signed-off-by: gbenhaim <galbh2@gmail.com>