### PR TITLE
 Make Lago operational without 'guestfs' module

### DIFF
--- a/lago/__init__.py
+++ b/lago/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014 Red Hat, Inc.
+# Copyright 2014-2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,3 +17,32 @@
 #
 # Refer to the README and COPYING files for full details of the license
 #
+import logging
+from textwrap import dedent
+from lago.validation import check_import
+
+LOGGER = logging.getLogger(__name__)
+ch = logging.StreamHandler()
+ch.setLevel(logging.WARNING)
+LOGGER.addHandler(ch)
+
+if not check_import('guestfs'):
+    pip_link = 'http://libguestfs.org/download/python/guestfs-1.XX.YY.tar.gz'
+
+    msg = dedent(
+        """
+            WARNING: - guestfs not found. Some Lago features will not work.
+            Please install it either by using your distribution package, or
+            with pip.
+
+            For Fedora/CentOS, run: yum install python2-libguestfs
+
+            For Debian, run: apt-get install python-libguestfs
+
+            For pip, go to http://libguestfs.org/download/python, pick
+            the version and run:
+
+            pip install {pip_link}
+        """.format(pip_link=pip_link)
+    )
+    LOGGER.warning(msg)

--- a/lago/guestfs_tools.py
+++ b/lago/guestfs_tools.py
@@ -1,0 +1,108 @@
+#
+# Copyright 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+#
+# Refer to the README and COPYING files for full details of the license
+#
+
+import os
+import guestfs
+import logging
+
+from lago.plugins.vm import ExtractPathError, ExtractPathNoPathError
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _copy_path(guestfs_conn, guest_path, host_path):
+    if guestfs_conn.is_file(guest_path):
+        with open(host_path, 'w') as dest_fd:
+            dest_fd.write(guestfs_conn.read_file(guest_path))
+
+    elif guestfs_conn.is_dir(guest_path):
+        os.mkdir(host_path)
+        for path in guestfs_conn.ls(guest_path):
+            _copy_path(
+                guestfs_conn,
+                os.path.join(
+                    guest_path,
+                    path,
+                ),
+                os.path.join(host_path, os.path.basename(path)),
+            )
+    else:
+        raise ExtractPathNoPathError(
+            ('unable to extract {0}: path does not '
+             'exist.').format(guest_path)
+        )
+
+
+def extract_paths(disk_path, disk_root, paths, ignore_nopath):
+    """
+    Extract paths from a disk using guestfs
+
+    Args:
+        disk_path(str): path to the disk
+        disk_root(str): root partition
+        paths(list of tuples): files to extract in
+            `[(src1, dst1), (src2, dst2)...]` format.
+        ignore_nopath(bool): If set to True, ignore source paths that do
+        not exist
+
+    Returns:
+        None
+
+    Raises:
+        :exc:`~lago.plugins.vm.ExtractPathNoPathError`: if a none existing
+            path was found on the VM, and `ignore_nopath` is False.
+        :exc:`~lago.plugins.vm.ExtractPathError`: on all other failures.
+    """
+
+    gfs_cli = guestfs.GuestFS(python_return_dict=True)
+    disk_path = os.path.expandvars(disk_path)
+    try:
+        gfs_cli.add_drive_opts(disk_path, format='qcow2', readonly=1)
+        gfs_cli.set_backend(os.environ.get('LIBGUESTFS_BACKEND', 'direct'))
+        gfs_cli.launch()
+        rootfs = [
+            filesystem for filesystem in gfs_cli.list_filesystems()
+            if disk_root in filesystem
+        ]
+        if not rootfs:
+            raise ExtractPathError(
+                'No root fs (%s) could be found for %s from list %s' %
+                (disk_root, disk_path, str(gfs_cli.list_filesystems()))
+            )
+        else:
+            rootfs = rootfs[0]
+        gfs_cli.mount_ro(rootfs, '/')
+        for (guest_path, host_path) in paths:
+            msg = ('Extracting guestfs://{0} to {1}').format(
+                guest_path, host_path
+            )
+
+            LOGGER.debug(msg)
+            try:
+                _copy_path(gfs_cli, guest_path, host_path)
+            except ExtractPathNoPathError as err:
+                if ignore_nopath:
+                    LOGGER.debug('%s: ignoring', err)
+                else:
+                    raise
+
+    finally:
+        gfs_cli.shutdown()
+        gfs_cli.close()

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -218,6 +218,13 @@ class VMProviderPlugin(plugins.Plugin):
         """
         return self.vm.interactive_ssh()
 
+    def extract_paths_dead(self, paths, ignore_nopath):
+        """
+        Extract the given paths from the domain, without the underlying OS
+        awareness
+        """
+        pass
+
     def extract_paths(self, paths, ignore_nopath):
         """
         Extract the given paths from the domain
@@ -372,6 +379,12 @@ class VMPlugin(plugins.Plugin):
         Thin method that just uses the provider
         """
         return self.provider.extract_paths(paths, *args, **kwargs)
+
+    def extract_paths_dead(self, paths, *args, **kwargs):
+        """
+        Thin method that just uses the provider
+        """
+        return self.provider.extract_paths_dead(paths, *args, **kwargs)
 
     def export_disks(
         self, standalone=True, dst_dir=None, compress=False, *args, **kwargs

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -23,19 +23,27 @@ import logging
 import os
 import pwd
 import time
+import sys
 
-import guestfs
 import libvirt
 from lxml import etree as ET
 
 from lago import export, log_utils, sysprep, utils
+from lago.utils import LagoException
 from lago.config import config
 from lago.plugins import vm as vm_plugin
-from lago.plugins.vm import ExtractPathError, ExtractPathNoPathError
+from lago.plugins.vm import ExtractPathError
 from lago.providers.libvirt import utils as libvirt_utils
 from lago.providers.libvirt import cpu
+from lago.validation import check_import
 
 LOGGER = logging.getLogger(__name__)
+
+if check_import('guestfs'):
+    from lago import guestfs_tools
+else:
+    LOGGER.debug('guestfs not available')
+
 LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
 log_task = functools.partial(log_utils.log_task, logger=LOGGER)
 
@@ -43,6 +51,7 @@ log_task = functools.partial(log_utils.log_task, logger=LOGGER)
 class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
     def __init__(self, vm):
         super(LocalLibvirtVMProvider, self).__init__(vm)
+        self._has_guestfs = 'lago.guestfs_tools' in sys.modules
         libvirt_url = config.get('libvirt_url')
         self.libvirt_con = libvirt_utils.get_libvirt_connection(
             name=self.vm.virt_env.uuid + libvirt_url,
@@ -264,10 +273,12 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
 
         Attempt to extract all files defined in ``paths`` with the method
         defined in :func:`~lago.plugins.vm.VMProviderPlugin.extract_paths`,
-        if it fails, will try extracting the files with libguestfs.
+        if it fails, and `guestfs` is available it will try extracting the
+        files with guestfs.
 
         Args:
-            paths(list of str): paths to extract
+            paths(list of tuples): files to extract in
+                `[(src1, dst1), (src2, dst2)...]` format.
             ignore_nopath(boolean): if True will ignore none existing paths.
 
         Returns:
@@ -275,7 +286,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
 
         Raises:
             :exc:`~lago.plugins.vm.ExtractPathNoPathError`: if a none existing
-                path was found on the VM, and `ignore_nopath` is True.
+                path was found on the VM, and `ignore_nopath` is False.
             :exc:`~lago.plugins.vm.ExtractPathError`: on all other failures.
         """
 
@@ -289,11 +300,49 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             LOGGER.debug(
                 '%s: failed extracting files: %s', self.vm.name(), err.message
             )
-            LOGGER.debug(
-                '%s: attempting to extract files with libguestfs',
-                self.vm.name()
+            if self._has_guestfs:
+                self.extract_paths_dead(paths, ignore_nopath)
+            else:
+                raise
+
+    def extract_paths_dead(self, paths, ignore_nopath):
+        """
+        Extract the given paths from the domain using guestfs.
+        Using guestfs can have side-effects and should be used as a second
+        option, mainly when SSH is not available.
+
+        Args:
+            paths(list of str): paths to extract
+            ignore_nopath(boolean): if True will ignore none existing paths.
+
+        Returns:
+            None
+
+        Raises:
+            :exc:`~lago.utils.LagoException`: if :mod:`guestfs` is not
+                importable.
+            :exc:`~lago.plugins.vm.ExtractPathNoPathError`: if a none existing
+                path was found on the VM, and `ignore_nopath` is True.
+            :exc:`~lago.plugins.vm.ExtractPathError`: on failure extracting
+                the files.
+        """
+        if not self._has_guestfs:
+            raise LagoException(
+                ('guestfs module not available, cannot '
+                 )('extract files with libguestfs')
             )
-            self._extract_paths_gfs(paths=paths, ignore_nopath=ignore_nopath)
+
+        LOGGER.debug(
+            '%s: attempting to extract files with libguestfs', self.vm.name()
+        )
+        guestfs_tools.extract_paths(
+            disk_path=self.vm.spec['disks'][0]['path'],
+            disk_root=self.vm.spec['disks'][0]['metadata'].get(
+                'root-partition', 'root'
+            ),
+            paths=paths,
+            ignore_nopath=ignore_nopath
+        )
 
     def export_disks(self, standalone, dst_dir, compress, *args, **kwargs):
         """
@@ -569,49 +618,6 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             self._reclaim_disks()
             self.vm._spec['snapshots'][name] = snap_info
 
-    def _extract_paths_gfs(self, paths, ignore_nopath):
-        gfs_cli = guestfs.GuestFS(python_return_dict=True)
-        try:
-            disk_path = os.path.expandvars(self.vm._spec['disks'][0]['path'])
-            disk_root_part = self.vm._spec['disks'][0]['metadata'].get(
-                'root-partition',
-                'root',
-            )
-            gfs_cli.add_drive_opts(disk_path, format='qcow2', readonly=1)
-            gfs_cli.set_backend(os.environ.get('LIBGUESTFS_BACKEND', 'direct'))
-            gfs_cli.launch()
-            rootfs = [
-                filesystem for filesystem in gfs_cli.list_filesystems()
-                if disk_root_part in filesystem
-            ]
-            if not rootfs:
-                raise RuntimeError(
-                    'No root fs (%s) could be found for %s from list %s' % (
-                        disk_root_part, disk_path,
-                        str(gfs_cli.list_filesystems())
-                    )
-                )
-            else:
-                rootfs = rootfs[0]
-            gfs_cli.mount_ro(rootfs, '/')
-            for (guest_path, host_path) in paths:
-                msg = ('Extracting guestfs://{0}:{1} to {2}').format(
-                    self.vm.name(), host_path, guest_path
-                )
-
-                LOGGER.debug(msg)
-                try:
-                    _guestfs_copy_path(gfs_cli, guest_path, host_path)
-                except ExtractPathNoPathError as err:
-                    if ignore_nopath:
-                        LOGGER.debug('%s: ignoring', err)
-                    else:
-                        raise
-
-        finally:
-            gfs_cli.shutdown()
-            gfs_cli.close()
-
     def _reclaim_disk(self, path):
         qemu_uid = None
         try:
@@ -626,26 +632,3 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
     def _reclaim_disks(self):
         for disk in self.vm._spec['disks']:
             self._reclaim_disk(disk['path'])
-
-
-def _guestfs_copy_path(guestfs_conn, guest_path, host_path):
-    if guestfs_conn.is_file(guest_path):
-        with open(host_path, 'w') as dest_fd:
-            dest_fd.write(guestfs_conn.read_file(guest_path))
-
-    elif guestfs_conn.is_dir(guest_path):
-        os.mkdir(host_path)
-        for path in guestfs_conn.ls(guest_path):
-            _guestfs_copy_path(
-                guestfs_conn,
-                os.path.join(
-                    guest_path,
-                    path,
-                ),
-                os.path.join(host_path, os.path.basename(path)),
-            )
-    else:
-        raise ExtractPathNoPathError(
-            ('unable to extract {0}: path does not '
-             'exist.').format(guest_path)
-        )

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -39,9 +39,6 @@ LOGGER = logging.getLogger(__name__)
 LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
 log_task = functools.partial(log_utils.log_task, logger=LOGGER)
 
-KDUMP_SERVICE = '/etc/systemd/system/multi-user.target.wants/kdump.service'
-POSTFIX_SERVICE = '/etc/systemd/system/multi-user.target.wants/postfix.service'
-
 
 class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
     def __init__(self, vm):

--- a/lago/validation.py
+++ b/lago/validation.py
@@ -1,0 +1,21 @@
+import logging
+import imp
+
+LOGGER = logging.getLogger(__name__)
+
+
+def check_import(module_name):
+    """
+    Search if a module exists, and it is possible to try importing it
+
+    Args:
+        module_name(str): module to import
+
+    Returns:
+        bool: True if the package is found
+    """
+    try:
+        imp.find_module(module_name)
+        return True
+    except ImportError:
+        return False

--- a/tests/functional-sdk/test_sdk_sanity.py
+++ b/tests/functional-sdk/test_sdk_sanity.py
@@ -100,16 +100,18 @@ def env(request, init_fname, test_results, tmp_workdir, external_log):
         loglevel=logging.DEBUG,
     )
     env.start()
-    yield env
-    collect_path = os.path.join(test_results, 'collect')
-    env.collect_artifacts(output_dir=collect_path, ignore_nopath=True)
-    shutil.copytree(
-        workdir,
-        os.path.join(test_results, 'workdir'),
-        ignore=shutil.ignore_patterns('*images*')
-    )
-    env.stop()
-    env.destroy()
+    try:
+        yield env
+        collect_path = os.path.join(test_results, 'collect')
+        env.collect_artifacts(output_dir=collect_path, ignore_nopath=True)
+        shutil.copytree(
+            workdir,
+            os.path.join(test_results, 'workdir'),
+            ignore=shutil.ignore_patterns('*images*')
+        )
+    finally:
+        env.stop()
+        env.destroy()
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
1. Extract all current functionality to lago/guestfs_tools.py, so we'll
have `import guestfs` only there.

2. Add an explicit method to extract files with guestfs:
    extract_paths_dead

3. Add some ugly checks if guestfs is available and throw exceptions
when needed.

4. Add a functional SDK test for `extract_paths/extract_paths_dead`


As a side note, I should say that I think we should refactor the "VM Provider" and "VM Plugin" concept, to something more maintainable and easier to extend. Theoretically I had to add one method(extract_paths_dead) to the libvirt provider. Practically, it required me to add it 3 places, either as an abstract method or as a proxy. And even with that - we don't even get the proper docstrings of the function(as it is proxied).

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>