### PR TITLE
Fixing export issues

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -344,15 +344,23 @@ def do_shutdown(prefix, vm_names, reboot, **kwargs):
     default='LagoInitFile',
     help='The name of the exported init file',
 )
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--collect-only',
+    action='store_true',
+    help='Only output the disks that will be exported',
+)
 @in_lago_prefix
 @with_logging
 def do_export(
     prefix, vm_names, standalone, dst_dir, compress, init_file_name,
-    out_format, **kwargs
+    out_format, collect_only, **kwargs
 ):
-    prefix.export_vms(
-        vm_names, standalone, dst_dir, compress, init_file_name, out_format
+    output = prefix.export_vms(
+        vm_names, standalone, dst_dir, compress, init_file_name, out_format,
+        collect_only
     )
+    if collect_only:
+        print(out_format.format(output))
 
 
 @lago.plugins.cli.cli_plugin(

--- a/lago/export.py
+++ b/lago/export.py
@@ -185,9 +185,16 @@ class TemplateExportManager(DiskExportManager):
                 # this identifier will be used later by Lago in order
                 # to resolve and download the base image
                 parent = self.src_qemu_info[0]['backing-filename']
-                parent = './{}'.format(
-                    os.path.basename(parent.split(':', 1)[1])
-                )
+                # Hack for working with lago images naming convention
+                # For example: /var/lib/lago/store/phx_repo:el7.3-base:v1
+                # Extract only the image name (in the example el7.3-base)
+                parent = os.path.basename(parent)
+                try:
+                    parent = parent.split(':', 1)[1]
+                except IndexError:
+                    pass
+
+                parent = './{}'.format(parent)
                 utils.qemu_rebase(
                     target=self.dst, backing_file=parent, safe=False
                 )

--- a/lago/export.py
+++ b/lago/export.py
@@ -243,7 +243,8 @@ class FileExportManager(DiskExportManager):
                     shutil.rmtree, self.dst, ignore_errors=True
                 )
                 self.copy()
-                self.sparse()
+                if not self.disk['format'] == 'iso':
+                    self.sparse()
                 self.calc_sha('sha1')
                 self.update_lago_metadata()
                 self.write_lago_metadata()

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -1221,12 +1221,18 @@ class Prefix(object):
         utils.invoke_in_parallel(build.Build.build, builders)
 
     def export_vms(
-        self, vms_names, standalone, export_dir, compress, init_file_name,
-        out_format
+        self,
+        vms_names,
+        standalone,
+        export_dir,
+        compress,
+        init_file_name,
+        out_format,
+        collect_only=False
     ):
-        self.virt_env.export_vms(
+        return self.virt_env.export_vms(
             vms_names, standalone, export_dir, compress, init_file_name,
-            out_format
+            out_format, collect_only
         )
 
     @sdk_utils.expose

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -31,6 +31,7 @@ import uuid
 import warnings
 import pkg_resources
 from os.path import join
+from plugins.output import YAMLOutFormatPlugin
 
 import xmltodict
 
@@ -1220,16 +1221,35 @@ class Prefix(object):
 
         utils.invoke_in_parallel(build.Build.build, builders)
 
+    @sdk_utils.expose
     def export_vms(
         self,
-        vms_names,
-        standalone,
-        export_dir,
-        compress,
-        init_file_name,
-        out_format,
+        vms_names=None,
+        standalone=False,
+        export_dir='.',
+        compress=False,
+        init_file_name='LagoInitFile',
+        out_format=YAMLOutFormatPlugin(),
         collect_only=False
     ):
+        """
+        Export vm images disks and init file.
+        The exported images and init file can be used to recreate
+        the environment.
+
+        Args:
+            vm_names(list of str): Names of the vms to export, if None
+                export all the vms in the env
+            standalone(bool): If false, export a layered image
+            export_dir(str): Dir to place the exported images and init file
+            compress(bool): If True compress the images with xz
+            init_file_name(str): The name of the exported init file
+            out_format(lago.plugins.output.OutFormatPlugin):
+                The type of the exported init file (the default is yaml)
+            collect_only(bool): If true, return only a mapping from vm name
+                to the disks that will be exported.
+
+        """
         return self.virt_env.export_vms(
             vms_names, standalone, export_dir, compress, init_file_name,
             out_format, collect_only

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -298,7 +298,15 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             )
             self._extract_paths_gfs(paths=paths, ignore_nopath=ignore_nopath)
 
-    def export_disks(self, standalone, dst_dir, compress, *args, **kwargs):
+    def export_disks(
+        self,
+        standalone,
+        dst_dir,
+        compress,
+        collect_only=False,
+        *args,
+        **kwargs
+    ):
         """
         Exports all the disks of self.
         For each disk type, handler function should be added.
@@ -308,8 +316,23 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
              image into a new file (Supported only in qcow2 format)
             dst_dir (str): dir to place the exported disks
             compress(bool): if true, compress each disk.
+            collect_only(bool): If true return only a dict with the names
+                of the disks that will be exported
 
         """
+
+        disks_to_export = (
+            disk for disk in self.vm.disks if not disk.get('skip-export')
+        )
+
+        if collect_only:
+            return {
+                self.vm.name():
+                    [
+                        os.path.basename(disk['path'])
+                        for disk in disks_to_export
+                    ]
+            }
 
         export_managers = [
             export.DiskExportManager.get_instance_by_type(
@@ -319,7 +342,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
                 standalone=standalone,
                 *args,
                 **kwargs
-            ) for disk in self.vm.disks if not disk.get('skip-export')
+            ) for disk in disks_to_export
         ]
 
         utils.invoke_different_funcs_in_parallel(

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -310,7 +310,6 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             compress(bool): if true, compress each disk.
 
         """
-        formats_to_exclude = {'iso'}
 
         export_managers = [
             export.DiskExportManager.get_instance_by_type(
@@ -320,8 +319,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
                 standalone=standalone,
                 *args,
                 **kwargs
-            ) for disk in self.vm.disks
-            if disk.get('format') not in formats_to_exclude
+            ) for disk in self.vm.disks if not disk.get('skip-export')
         ]
 
         utils.invoke_different_funcs_in_parallel(

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -326,13 +326,11 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
         )
 
         if collect_only:
-            return {
-                self.vm.name():
-                    [
-                        os.path.basename(disk['path'])
-                        for disk in disks_to_export
-                    ]
-            }
+            names = [
+                os.path.basename(disk['path']) for disk in disks_to_export
+            ]
+
+            return {self.vm.name(): names}
 
         export_managers = [
             export.DiskExportManager.get_instance_by_type(

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -17,6 +17,7 @@
 #
 # Refer to the README and COPYING files for full details of the license
 #
+from copy import deepcopy
 import functools
 import hashlib
 import json
@@ -173,7 +174,8 @@ class VirtEnv(object):
         for name in vms_names:
             try:
                 vm = self._vms[name]
-                vms.append(vm)
+                if not vm.spec.get('skip-export'):
+                    vms.append(vm)
                 if vm.defined():
                     running_vms.append(vm)
             except KeyError:
@@ -197,9 +199,11 @@ class VirtEnv(object):
 
             utils.invoke_in_parallel(_export_disks, vms)
 
-        self.generate_init(os.path.join(dst_dir, init_file_name), out_format)
+        self.generate_init(
+            os.path.join(dst_dir, init_file_name), out_format, vms
+        )
 
-    def generate_init(self, dst, out_format, filters=None):
+    def generate_init(self, dst, out_format, vms_to_include, filters=None):
         """
         Generate an init file which represents this env and can
         be used with the images created by self.export_vms
@@ -210,6 +214,8 @@ class VirtEnv(object):
                 formatter for the output (the default is yaml)
             filters (list): list of paths to keys that should be removed from
                 the init file
+            vms_to_include (list of lago.plugins.vm.VMPlugin): list of vms to
+                include in the init file
         Returns:
             None
         """
@@ -226,9 +232,20 @@ class VirtEnv(object):
                     'domains/*/metadata/deploy-scripts', 'domains/*/snapshots',
                     'domains/*/name', 'nets/*/mapping', 'nets/*/dns_records'
                 ]
+
             spec = self.get_env_spec(filters)
+            temp = {}
+
+            for vm in vms_to_include:
+                temp[vm.name()] = spec['domains'][vm.name()]
+
+            spec['domains'] = temp
 
             for _, domain in spec['domains'].viewitems():
+                domain['disks'] = [
+                    d for d in domain['disks'] if not d.get('skip-export')
+                ]
+
                 for disk in domain['disks']:
                     if disk['type'] == 'template':
                         disk['template_type'] = 'qcow2'
@@ -264,12 +281,12 @@ class VirtEnv(object):
         spec = {
             'domains':
                 {
-                    vm_name: vm_object.spec
+                    vm_name: deepcopy(vm_object.spec)
                     for vm_name, vm_object in self._vms.viewitems()
                 },
             'nets':
                 {
-                    net_name: net_object.spec
+                    net_name: deepcopy(net_object.spec)
                     for net_name, net_object in self._nets.viewitems()
                 }
         }


### PR DESCRIPTION
1. Allow specifying in the init file which vms / disks to export.
2. Don't run virt-sparsify on iso disks.
3. Use deepcopy when generating the env's spec (will help
   to avoid unwanted changes to the internal metadata of the env).
4. Adding collect-only: only show which disks are going to be exported.
5. Expose export to lago.sdk
6. Safely try to parse the name of the backing image