### PR TITLE
Fix sdist creation

### DIFF
--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -13,10 +13,12 @@ echo "cleaning $YUM metadata"
 $YUM clean metadata
 
 echo "cleaning $BUILDS, $EXPORTS"
-rm -rf "$BUILDS" "$EXPORTS"/*{.rpm,.tar.gz}
+rm -rf "$BUILDS" "$EXPORTS"/*{.rpm,.tar.gz} "$DIST"
 mkdir -p "$BUILDS"
 mkdir -p "$EXPORTS"
 
+make clean
+make python-sdist DIST_DIR="$PWD/exported-artifacts"
 make clean
 make lago.spec
 
@@ -26,6 +28,4 @@ $BUILDDEP -y lago.spec
 echo "creating RPM"
 make rpm OUTPUT_DIR="$BUILDS"
 
-find "$BUILDS" \
-    \( -iname \*.rpm -or -iname \*.tar.gz \) \
-    -exec mv {} "$EXPORTS/" \;
+find "$BUILDS" -iname "*.rpm" -exec mv {} "$EXPORTS/" \;

--- a/automation/common.sh
+++ b/automation/common.sh
@@ -92,6 +92,9 @@ run_installation_tests() {
     else
         yum=yum
     fi
+    echo "Running sdist installation tests"
+    tox -v -r -e sdist
+
     # fail if a glob turns out empty
     shopt -s failglob
     for package in {python-,}lago ; do

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,13 @@ deps =
 
 whitelist_externals = /bin/bash
 
+[testenv:sdist]
+passenv=PIP_CACHE_DIR
+deps =
+    {toxinidir}/exported-artifacts/lago*.tar.gz
+commands = lago --version
+whitelist_externals = /bin/bash
+
 [testenv:docs]
 passenv=PIP_CACHE_DIR HOME
 skip_install=True


### PR DESCRIPTION
1. First build the sdist to exported-artifacts.
2. Then build the RPMs(which also create an sdist - but manipulate it).
3. Add installation test from the sdist we exported(and don't let tox
produce it by itself, because that is not the one we publish).
4. Lastly, don't publish the 'tar.gz' the RPMs used, only the sdist.

This avoids the corruption in the sdist that our RPM related scripts
caused(in Makefile). So we ensure the 'sdist' we publish is the one
produced by 'python setup.py sdist'.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>