### PR TITLE
export: Some fixes

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -344,15 +344,28 @@ def do_shutdown(prefix, vm_names, reboot, **kwargs):
     default='LagoInitFile',
     help='The name of the exported init file',
 )
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--collect-only',
+    action='store_true',
+    help='Only output the disks that will be exported',
+)
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--without-threads',
+    action='store_true',
+    help='If set, do not use threads',
+)
 @in_lago_prefix
 @with_logging
 def do_export(
     prefix, vm_names, standalone, dst_dir, compress, init_file_name,
-    out_format, **kwargs
+    out_format, collect_only, without_threads, **kwargs
 ):
-    prefix.export_vms(
-        vm_names, standalone, dst_dir, compress, init_file_name, out_format
+    output = prefix.export_vms(
+        vm_names, standalone, dst_dir, compress, init_file_name, out_format,
+        collect_only, not without_threads
     )
+    if collect_only:
+        print(out_format.format(output))
 
 
 @lago.plugins.cli.cli_plugin(

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -387,13 +387,21 @@ class VMPlugin(plugins.Plugin):
         return self.provider.extract_paths_dead(paths, *args, **kwargs)
 
     def export_disks(
-        self, standalone=True, dst_dir=None, compress=False, *args, **kwargs
+        self,
+        standalone=True,
+        dst_dir=None,
+        compress=False,
+        collect_only=False,
+        with_threads=True,
+        *args,
+        **kwargs
     ):
         """
         Thin method that just uses the provider
         """
         return self.provider.export_disks(
-            standalone, dst_dir, compress, *args, **kwargs
+            standalone, dst_dir, compress, collect_only, with_threads, *args,
+            **kwargs
         )
 
     def copy_to(self, local_path, remote_path, recursive=True):

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -31,6 +31,7 @@ import uuid
 import warnings
 import pkg_resources
 from os.path import join
+from plugins.output import YAMLOutFormatPlugin
 
 import xmltodict
 
@@ -1220,13 +1221,47 @@ class Prefix(object):
 
         utils.invoke_in_parallel(build.Build.build, builders)
 
+    @sdk_utils.expose
     def export_vms(
-        self, vms_names, standalone, export_dir, compress, init_file_name,
-        out_format
+        self,
+        vms_names=None,
+        standalone=False,
+        export_dir='.',
+        compress=False,
+        init_file_name='LagoInitFile',
+        out_format=YAMLOutFormatPlugin(),
+        collect_only=False,
+        with_threads=True,
     ):
-        self.virt_env.export_vms(
+        """
+        Export vm images disks and init file.
+        The exported images and init file can be used to recreate
+        the environment.
+
+        Args:
+            vms_names(list of str): Names of the vms to export, if None
+                export all the vms in the env (default=None)
+            standalone(bool): If false, export a layered image
+                (default=False)
+            export_dir(str): Dir to place the exported images and init file
+            compress(bool): If True compress the images with xz
+                  (default=False)
+            init_file_name(str): The name of the exported init file
+                (default='LagoInitfile')
+            out_format(:class:`lago.plugins.output.OutFormatPlugin`):
+                The type of the exported init file (the default is yaml)
+            collect_only(bool): If True, return only a mapping from vm name
+                to the disks that will be exported. (default=False)
+            with_threads(bool): If True, run the export in parallel
+                (default=True)
+
+        Returns
+            Unless collect_only == True, a mapping between vms' disks.
+
+        """
+        return self.virt_env.export_vms(
             vms_names, standalone, export_dir, compress, init_file_name,
-            out_format
+            out_format, collect_only, with_threads
         )
 
     @sdk_utils.expose

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -97,13 +97,13 @@ class VectorThread:
 def invoke_in_parallel(func, *args_sequences):
     vt = VectorThread(func_vector(func, zip(*args_sequences)))
     vt.start_all()
-    vt.join_all()
+    return vt.join_all()
 
 
 def invoke_different_funcs_in_parallel(*funcs):
     vt = VectorThread(funcs)
     vt.start_all()
-    vt.join_all()
+    return vt.join_all()
 
 
 _CommandStatus = collections.namedtuple(


### PR DESCRIPTION
1. Allow to specify in the init file which vms / disks to export.

2. Don't run virt-sparsify on iso disks.

3. Use deepcopy when generating the env's spec (will help
   to avoid unwanted changes to the internal metadata of the env).

4. Adding collect only option to export cmd: This option will output
   the mapping from vms to the disks that will be exported.

5. Expose export to lago.sdk

6. Safely try to parse the name of the backing image:
   Due to lago image store naming convention (repo:image:version),
   if the backing image is a Lago image, preprocessing to the name
   needs to be done (in order to extract only the image name and the
   version) and then set it as the backing image of the exported image.

   Since not always the backing image will be a Lago images, adding
   exception handling to the parsing stage.

7. Adding VMExportManager: Becuase of the functionality that was added
   (as described above), the code became complex, so adding
   VMExportManager as an abstraction.

8. Adding the ability to choose if to use threads.

9. prefix.export_vms will return a dict that maps between
   vms names and the path of the disks that were exported.

10. Return threads results from utils.invoke_in_parallel and
    utils.invoke_different_funcs_in_parallel.

Signed-off-by: gbenhaim <galbh2@gmail.com>