### PR TITLE
Get libvirt version correctly

### DIFF
--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -57,7 +57,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             name=self.vm.virt_env.uuid + libvirt_url,
             libvirt_url=libvirt_url,
         )
-        self._libvirt_ver = self.libvirt_con.getVersion()
+        self._libvirt_ver = self.libvirt_con.getLibVersion()
 
         caps_raw_xml = self.libvirt_con.getCapabilities()
         self._caps = ET.fromstring(caps_raw_xml)


### PR DESCRIPTION
In f8be8f4d892149669c9f1abc4bdaf67cc9a5ae2c I misused 'getVersion'
instead of 'getLibVersion'. The first returns the hypervisor version
which was not the intention.

Tested locally where it matters: started with lago a Ubuntu 16.04 VM -> installed Lago from pip -> started a el7.3 nested VM.


Signed-off-by: Nadav Goldin <ngoldin@redhat.com>