### PR TITLE
spec: force libguestfs >= 1.30

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -83,11 +83,11 @@ BuildRequires: python-netaddr
 
 
 Requires: python
-Requires: libguestfs-tools
-Requires: libguestfs-devel
+Requires: libguestfs-tools >= 1.30
+Requires: libguestfs-devel >= 1.30
 Requires: libvirt >= 1.2.8
 Requires: libvirt-python
-Requires: python-libguestfs
+Requires: python-libguestfs >= 1.30
 Requires: python-lxml
 Requires: python-lockfile
 Requires: python-pbr


### PR DESCRIPTION
Older versions don't have '--commands-from-file' which we use now
by default.

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>