### PR TITLE
guestfs: refactoring

### DIFF
--- a/lago/guestfs_tools.py
+++ b/lago/guestfs_tools.py
@@ -22,33 +22,151 @@ import os
 import guestfs
 import logging
 import time
-
-from lago.plugins.vm import ExtractPathError, ExtractPathNoPathError
+import contextlib
+from lago.plugins.vm import ExtractPathNoPathError
+from lago.utils import LagoException
 
 LOGGER = logging.getLogger(__name__)
 
 
-def _copy_path(guestfs_conn, guest_path, host_path):
-    if guestfs_conn.is_file(guest_path):
-        with open(host_path, 'w') as dest_fd:
-            dest_fd.write(guestfs_conn.read_file(guest_path))
+class GuestFSError(LagoException):
+    pass
 
-    elif guestfs_conn.is_dir(guest_path):
-        os.mkdir(host_path)
-        for path in guestfs_conn.ls(guest_path):
-            _copy_path(
-                guestfs_conn,
-                os.path.join(
-                    guest_path,
-                    path,
-                ),
-                os.path.join(host_path, os.path.basename(path)),
-            )
-    else:
-        raise ExtractPathNoPathError(
-            ('unable to extract {0}: path does not '
-             'exist.').format(guest_path)
+
+@contextlib.contextmanager
+def guestfs_conn_ro(disk):
+    """
+    Open a GuestFS handle and add `disk` in read only mode.
+
+    Args:
+        disk(disk path): Path to the disk.
+
+    Yields:
+        guestfs.GuestFS: Open GuestFS handle
+
+    Raises:
+        :exc:`GuestFSError`: On any guestfs operation failure
+    """
+
+    disk_path = os.path.expandvars(disk)
+    conn = guestfs.GuestFS(python_return_dict=True)
+    conn.add_drive_ro(disk_path)
+    conn.set_backend(os.environ.get('LIBGUESTFS_BACKEND', 'direct'))
+    try:
+        conn.launch()
+    except RuntimeError as err:
+        LOGGER.debug(err)
+        raise GuestFSError(
+            'failed starting guestfs in readonly mode for disk: {0}'.
+            format(disk)
         )
+    try:
+        yield conn
+    finally:
+        conn.shutdown()
+        conn.close()
+
+
+@contextlib.contextmanager
+def guestfs_conn_mount_ro(disk_path, disk_root, retries=5, wait=1):
+    """
+    Open a GuestFS handle with `disk_path` and try mounting the root
+    filesystem. `disk_root` is a hint where it should be looked and will
+    only be used if GuestFS will not be able to deduce it independently.
+
+    Note that mounting a live guest, can lead to filesystem inconsistencies,
+    causing the mount operation to fail. As we use readonly mode, this is
+    safe, but the operation itself can still fail. Therefore, this method
+    will watch for mount failures and retry 5 times before throwing
+    an exception.
+
+
+    Args:
+        disk_path(str): Path to the disk.
+        disk_root(str): Hint what is the root device with the OS filesystem.
+        retries(int): Number of retries for :func:`~guestfs.GuestFS.mount_ro`
+            operation. Note that on each retry a new GuestFS handle will
+            be used.
+        wait(int): Time to wait between retries.
+
+    Yields:
+        guestfs.GuestFS: An open GuestFS handle.
+
+    Raises:
+        :exc:`GuestFSError`: On any guestfs operation error, including
+            exceeding retries for the :func:`~guestfs.GuestFS.mount_ro`
+            operation.
+
+    """
+
+    for attempt in range(retries):
+        with guestfs_conn_ro(disk_path) as conn:
+            rootfs = find_rootfs(conn, disk_root)
+            try:
+                conn.mount_ro(rootfs, '/')
+            except RuntimeError as err:
+                LOGGER.debug(err)
+                if attempt < retries - 1:
+                    LOGGER.debug(
+                        (
+                            'failed mounting %s:%s using guestfs, '
+                            'attempt %s/%s'
+                        ), disk_path, rootfs, attempt + 1, retries
+                    )
+                    time.sleep(wait)
+                    continue
+                else:
+                    raise GuestFSError(
+                        'failed mounting {0}:{1} using guestfs'.
+                        format(disk_path, rootfs)
+                    )
+            yield conn
+            try:
+                conn.umount(rootfs)
+            except RuntimeError as err:
+                LOGGER.debug(err)
+                raise GuestFSError(
+                    ('failed unmounting {0}:{1} using'
+                     'guestfs').format(disk_path, rootfs)
+                )
+            break
+
+
+def find_rootfs(conn, disk_root):
+    """
+    Find the image's device root filesystem, and return its path.
+
+    1. Use :func:`guestfs.GuestFS.inspect_os` method. If it returns more than
+        one root filesystem or None, try:
+    2. Find an exact match of `disk_root` from
+        :func:`guestfs.GuestFS.list_filesystems`, if none is found, try:
+    3. Return the device that has the substring `disk_root` contained in it,
+        from the output of :func:`guestfs.GuestFS.list_filesystems`.
+
+    Args:
+        conn(guestfs.GuestFS): Open GuestFS handle.
+        disk_root(str): Root device to search for. Note that by default, if
+            guestfs can deduce the filesystem, it will not be used.
+
+    Returns:
+        str: root device path
+
+    Raises:
+        :exc:`GuestFSError` if no root filesystem was found
+    """
+    rootfs = conn.inspect_os()
+    if not rootfs or len(rootfs) > 1:
+        filesystems = conn.list_filesystems()
+        if disk_root in filesystems:
+            rootfs = [disk_root]
+        else:
+            rootfs = [fs for fs in filesystems.keys() if disk_root in fs]
+            if not rootfs:
+                raise GuestFSError(
+                    'no root fs {0} could be found from list {1}'.
+                    format(disk_root, str(filesystems))
+                )
+    return sorted(rootfs)[0]
 
 
 def extract_paths(disk_path, disk_root, paths, ignore_nopath):
@@ -59,61 +177,23 @@ def extract_paths(disk_path, disk_root, paths, ignore_nopath):
         disk_path(str): path to the disk
         disk_root(str): root partition
         paths(list of tuples): files to extract in
-            `[(src1, dst1), (src2, dst2)...]` format.
-        ignore_nopath(bool): If set to True, ignore source paths that do
-        not exist
+            `[(src1, dst1), (src2, dst2)...]` format, if ``srcN`` is a
+            directory in the guest, and ``dstN`` does not exist on the host,
+            it will be created. If ``srcN`` is a file on the guest, it will be
+            copied exactly to ``dstN``
+        ignore_nopath(bool): If set to True, ignore paths in the guest that
+            do not exit
 
     Returns:
         None
 
     Raises:
         :exc:`~lago.plugins.vm.ExtractPathNoPathError`: if a none existing
-            path was found on the VM, and `ignore_nopath` is False.
+            path was found on the guest, and `ignore_nopath` is False.
         :exc:`~lago.plugins.vm.ExtractPathError`: on all other failures.
     """
 
-    gfs_cli = guestfs.GuestFS(python_return_dict=True)
-    disk_path = os.path.expandvars(disk_path)
-    try:
-        gfs_cli.add_drive_ro(disk_path)
-        gfs_cli.set_backend(os.environ.get('LIBGUESTFS_BACKEND', 'direct'))
-        gfs_cli.launch()
-        rootfs = [
-            filesystem for filesystem in gfs_cli.list_filesystems()
-            if disk_root in filesystem
-        ]
-        if not rootfs:
-            raise ExtractPathError(
-                'No root fs (%s) could be found for %s from list %s' %
-                (disk_root, disk_path, str(gfs_cli.list_filesystems()))
-            )
-        else:
-            rootfs = rootfs[0]
-
-        max_attempts = 5
-        for attempt in range(max_attempts):
-            try:
-                gfs_cli.mount_ro(rootfs, '/')
-                break
-            except RuntimeError as err:
-                if attempt <= max_attempts:
-                    LOGGER.debug(err)
-                    LOGGER.debug(
-                        (
-                            'failed mounting %s:%s using guestfs, '
-                            'attempt %s/%s'
-                        ), disk_path, rootfs, attempt + 1, max_attempts
-                    )
-                    time.sleep(1)
-                else:
-                    LOGGER.debug(
-                        (
-                            'failed mounting %s:%s using guestfs', disk_path,
-                            rootfs
-                        )
-                    )
-                    raise
-
+    with guestfs_conn_mount_ro(disk_path, disk_root) as conn:
         for (guest_path, host_path) in paths:
             msg = ('Extracting guestfs://{0} to {1}').format(
                 guest_path, host_path
@@ -121,13 +201,37 @@ def extract_paths(disk_path, disk_root, paths, ignore_nopath):
 
             LOGGER.debug(msg)
             try:
-                _copy_path(gfs_cli, guest_path, host_path)
+                _copy_path(conn, guest_path, host_path)
             except ExtractPathNoPathError as err:
                 if ignore_nopath:
-                    LOGGER.debug('%s: ignoring', err)
+                    LOGGER.debug('%s - ignoring', err)
                 else:
                     raise
 
-    finally:
-        gfs_cli.shutdown()
-        gfs_cli.close()
+
+def _copy_path(conn, guest_path, host_path):
+    if conn.is_file(guest_path, followsymlinks=True):
+        try:
+            conn.download(guest_path, host_path)
+        except RuntimeError as err:
+            LOGGER.debug(err)
+            raise GuestFSError(
+                'failed copying file {0} to {1} using guestfs'.
+                format(guest_path, host_path)
+            )
+    elif conn.is_dir(guest_path, followsymlinks=True):
+        if not os.path.isdir(host_path):
+            os.makedirs(host_path)
+        try:
+            conn.copy_out(guest_path, host_path)
+        except RuntimeError as err:
+            LOGGER.debug(err)
+            raise GuestFSError(
+                'failed copying directory {0} to {1} using guestfs'.
+                format(guest_path, host_path)
+            )
+    else:
+        raise ExtractPathNoPathError(
+            ('unable to extract {0}: path does not '
+             'exist.').format(guest_path)
+        )

--- a/tests/functional-sdk/utils.py
+++ b/tests/functional-sdk/utils.py
@@ -1,0 +1,61 @@
+import os
+import uuid
+import random
+
+
+class RandomizedDir(object):
+    def __init__(self, path, depth, max_files=30):
+        """
+        Create a random number of directories with a random number of files,
+        with random one line data in each file
+
+
+        Args:
+            path(str): root path to create the directory
+            depth(int): In each round a random number between 1 and ``depth``
+                directories will be created. For each directory in the next
+                round depth will be decreased by one.
+                Must be greater than 1.
+            max_files(int): In each directory a random number between 0
+                to ``max_files`` files will be created in each directory.
+
+        Returns:
+            None
+        """
+        if depth <= 1:
+            raise ValueError('depth must be greater than 1')
+
+        self.path = path
+        self.depth = depth
+        self.max_files = max_files
+        self.files = []
+        self.dirs = []
+        self._used_uuids = set()
+        self._randomized_dir(self.path, self.depth)
+
+    def _randomized_dir(self, path, depth):
+        if depth <= 1:
+            return
+        local_depth = random.randint(1, depth)
+        for level in range(local_depth):
+            num_files = random.randint(0, self.max_files)
+            for rand_file in range(num_files):
+                fname = os.path.join(path, self._uuid().hex[-8:])
+                with open(fname, 'w') as f:
+                    f.write(self._uuid().hex)
+                self.files.append(fname)
+            rand_dir = os.path.join(path, self._uuid().hex[-8:])
+            os.makedirs(rand_dir)
+            self.dirs.append(rand_dir)
+            self._randomized_dir(rand_dir, local_depth - 1)
+
+    def _uuid(self):
+        candidate = None
+        while True:
+            candidate = uuid.uuid4()
+            # the probability is really low to have a collision
+            # but who knows..
+            if candidate not in self._used_uuids:
+                break
+        self._used_uuids.add(candidate)
+        return candidate

--- a/tests/functional/collect.bats
+++ b/tests/functional/collect.bats
@@ -37,7 +37,7 @@ REPO_NAME="local_tests_repo"
     pushd "$FIXTURES"
     outdir="$FIXTURES/output"
     rm -rf "$outdir"
-    helpers.run_ok "$LAGOCLI" collect --output "$outdir"
+    helpers.run_ok "$LAGOCLI" --loglevel=debug collect --output "$outdir"
 }
 
 @test "collect: fails if files to collect don't exist and no-skip is set" {
@@ -45,7 +45,7 @@ REPO_NAME="local_tests_repo"
     pushd "$FIXTURES"
     outdir="$FIXTURES/output"
     rm -rf "$outdir"
-    helpers.run_nook "$LAGOCLI" collect --no-skip --output "$outdir"
+    helpers.run_nook "$LAGOCLI" --loglevel=debug collect --no-skip --output "$outdir"
 }
 
 
@@ -71,7 +71,7 @@ EOC
     )
 
     rm -rf "$outdir"
-    helpers.run_ok "$LAGOCLI" collect --output "$outdir"
+    helpers.run_ok "$LAGOCLI" --loglevel=debug collect --output "$outdir"
 
     for host in vm01; do
         helpers.is_dir "$outdir/$host"
@@ -107,7 +107,7 @@ EOC
 
     rm -rf "$outdir"
     mkdir "$outdir"
-    helpers.run_ok "$LAGOCLI" collect --output "$outdir"
+    helpers.run_ok "$LAGOCLI" --loglevel=debug collect --output "$outdir"
 
     for host in vm01; do
         helpers.is_dir "$outdir/$host"

--- a/tests/unit/lago/test_guestfs_tools.py
+++ b/tests/unit/lago/test_guestfs_tools.py
@@ -1,0 +1,366 @@
+import pytest
+from mock import call, patch
+from lago import guestfs_tools
+from lago.plugins.vm import ExtractPathNoPathError
+from lago.guestfs_tools import GuestFSError
+from random import shuffle
+
+# An alternative approach to 'MockGuestFS' class would have been using mock's
+# autospec, i.e.:
+# @pytest.fixture
+#   def mock_gfs():
+#        with patch(
+#            'lago.guestfs_tools.guestfs.GuestFS', autospec=True
+#        ) as mocked:
+#            yield mocked
+# But, turns out 'autospec' in this case is extremely slow(around 1 second
+# for each test).
+# see: https://docs.python.org/3/library/unittest.mock.html#autospeccing
+# for possible reasons(probably dynamic code execution).
+
+
+class MockGuestFS(object):
+    def inspect_os(self):
+        pass
+
+    def list_filesystems(self):
+        pass
+
+    def mount_ro(self):
+        pass
+
+    def umount(self):
+        pass
+
+    def add_drive_ro(self):
+        pass
+
+    def set_backend(self):
+        pass
+
+    def launch(self):
+        pass
+
+    def shutdown(self):
+        pass
+
+    def close(self):
+        pass
+
+    def download(self):
+        pass
+
+    def is_file(self):
+        pass
+
+    def is_dir(self):
+        pass
+
+    def copy_out(self):
+        pass
+
+
+@pytest.fixture
+def mock_gfs():
+    with patch(
+        'lago.guestfs_tools.guestfs.GuestFS', spec=MockGuestFS
+    ) as mocked:
+        yield mocked
+
+
+@pytest.fixture
+def mock_gfs_fs(mock_gfs):
+    mock_gfs.return_value.inspect_os.return_value = ['/dev/sda1']
+    return mock_gfs.return_value
+
+
+class TestGuestFSTools(object):
+    @pytest.mark.parametrize(
+        'filesystems,root_device', [
+            ({
+                '/dev/sdb': ''
+            }, '/dev/sdb'), (
+                {
+                    '/dev/sdb': '',
+                    '/dev/sdz': '',
+                    '/dev/vda': '',
+                    '/dev/sdr': ''
+                }, '/dev/sdz'
+            )
+        ]
+    )
+    def test_find_rootfs_fullname(self, mock_gfs, filesystems, root_device):
+        mock_gfs.inspect_os.return_value = []
+        mock_gfs.list_filesystems.return_value = filesystems
+        res = guestfs_tools.find_rootfs(mock_gfs, root_device)
+        mock_gfs.list_filesystems.assert_called()
+        assert res == root_device
+
+    @pytest.mark.parametrize(
+        'filesystems,root_device,expected', [
+            ({
+                '/a/dev/sda': ''
+            }, '/dev/sda', '/a/dev/sda'),
+            ({
+                '/dev/sdb': '',
+                '/path/to/sdz': ''
+            }, 'sdz', '/path/to/sdz')
+        ]
+    )
+    def test_find_rootfs_substring(
+        self, mock_gfs, filesystems, root_device, expected
+    ):
+        mock_gfs.inspect_os.return_value = []
+        mock_gfs.list_filesystems.return_value = filesystems
+        res = guestfs_tools.find_rootfs(mock_gfs, root_device)
+        mock_gfs.list_filesystems.assert_called()
+        assert res == expected
+
+    def test_find_rootfs_empty(self, mock_gfs):
+        mock_gfs.inspect_os.return_value = []
+        mock_gfs.list_filesystems.return_value = {}
+        with pytest.raises(GuestFSError):
+            guestfs_tools.find_rootfs(mock_gfs, '/dev/sda')
+        mock_gfs.list_filesystems.assert_called()
+
+    @pytest.mark.parametrize(
+        'filesystems,root_device', [
+            ({}, 'abc'),
+            ({
+                '/dev/sda': ''
+            }, '/dev/sdb'),
+        ]
+    )
+    def test_find_rootfs_raises(self, mock_gfs, filesystems, root_device):
+        mock_gfs.inspect_os.return_value = []
+        mock_gfs.list_filesystems.return_value = filesystems
+        with pytest.raises(GuestFSError):
+            guestfs_tools.find_rootfs(mock_gfs, root_device)
+        mock_gfs.list_filesystems.assert_called()
+
+    def test_guestfs_conn_ro_fallback_backend(self, mock_gfs):
+        with guestfs_tools.guestfs_conn_ro(disk='dummy') as conn:
+            assert conn.set_backend.call_args == call('direct')
+
+    def test_guestfs_conn_ro_env_backend(self, monkeypatch, mock_gfs):
+        monkeypatch.setenv('LIBGUESTFS_BACKEND', 'libvirt')
+        with guestfs_tools.guestfs_conn_ro(disk='dummy') as conn:
+            assert conn.set_backend.call_args == call('libvirt')
+
+    def test_guestfs_conn_ro_expand_vars(self, mock_gfs, monkeypatch):
+        expanded_path = '/some/path'
+        monkeypatch.setenv('SOME_PATH', expanded_path)
+        with guestfs_tools.guestfs_conn_ro(disk='$SOME_PATH/file') as conn:
+            assert conn.add_drive_ro.call_args == call('/some/path/file')
+
+    def test_guestfs_conn_ro_expand_wrong_var(self, mock_gfs, monkeypatch):
+        monkeypatch.delenv('SOME_PATH', raising=False)
+        with guestfs_tools.guestfs_conn_ro(disk='$SOME_PATH/file') as conn:
+            assert conn.add_drive_ro.call_args == call('$SOME_PATH/file')
+
+    def test_guestfs_conn_ro_teardown(self, mock_gfs):
+        with guestfs_tools.guestfs_conn_ro(disk='dummy') as conn:
+            pass
+        assert call.add_drive_ro('dummy') in conn.mock_calls
+        assert conn.mock_calls[-1] == call.close()
+        assert conn.mock_calls[-2] == call.shutdown()
+
+    def test_guestfs_conn_ro_error(self, mock_gfs):
+        mock_gfs.return_value.launch.side_effect = RuntimeError('mocking')
+        with pytest.raises(guestfs_tools.GuestFSError):
+            with guestfs_tools.guestfs_conn_ro(disk='dummy'):
+                pass
+
+    @pytest.mark.parametrize(
+        'disk_path,disk_root', [('/path/to/file.qcow', '/dev/sda')]
+    )
+    def test_guestfs_conn_mount_ro(self, mock_gfs, disk_path, disk_root):
+        with patch('lago.guestfs_tools.find_rootfs') as mock_rootfs:
+            mock_rootfs.return_value = disk_root
+            with guestfs_tools.guestfs_conn_mount_ro(
+                disk_path, disk_root
+            ) as conn:
+                assert call.mount_ro(disk_root, '/') in conn.mock_calls
+                assert call.add_drive_ro(disk_path) in conn.mock_calls
+                conn.mount_ro.assert_called_once()
+                conn.add_drive_ro.assert_called_once()
+                mock_rootfs.assert_called_once()
+            mock_gfs.return_value.umount.assert_called_once()
+
+    @pytest.mark.parametrize(
+        'disk_path,disk_root', [('/path/to/file.qcow', '/dev/sda')]
+    )
+    @pytest.mark.parametrize('retries', [1, 3, 13])
+    def test_guestfs_conn_mount_ro_retries(
+        self, mock_gfs, disk_path, disk_root, retries
+    ):
+        side_effects = [RuntimeError()] * (retries - 1)
+        side_effects.append(None)
+        mock_gfs.return_value.mount_ro.side_effect = side_effects
+        with patch('lago.guestfs_tools.find_rootfs') as mock_rootfs:
+            mock_rootfs.return_value = disk_root
+            with guestfs_tools.guestfs_conn_mount_ro(
+                disk_path, disk_root, retries=retries, wait=0
+            ) as conn:
+
+                assert call.mount_ro(disk_root, '/') in conn.mock_calls
+                assert call.add_drive_ro(disk_path) in conn.mock_calls
+            assert conn.mount_ro.call_count == retries
+            assert conn.umount.call_count == 1
+            assert conn.add_drive_ro.call_count == retries
+            assert conn.shutdown.call_count == retries
+            assert conn.close.call_count == retries
+
+    @pytest.mark.parametrize(
+        'disk_path,disk_root', [('/path/to/file.qcow', '/dev/sda')]
+    )
+    @pytest.mark.parametrize('retries', [1, 3])
+    def test_guestfs_conn_mount_ro_retries_raises(
+        self, mock_gfs, disk_path, disk_root, retries
+    ):
+        side_effects = [RuntimeError()] * (retries)
+        mock_gfs.return_value.mount_ro.side_effect = side_effects
+        with patch('lago.guestfs_tools.find_rootfs') as mock_rootfs:
+            mock_rootfs.return_value = disk_root
+            with pytest.raises(GuestFSError):
+                with guestfs_tools.guestfs_conn_mount_ro(
+                    disk_path, disk_root, retries=retries, wait=0
+                ):
+                    pass
+
+            assert mock_gfs.return_value.mount_ro.call_count == retries
+            assert mock_gfs.return_value.umount.call_count == 0
+            assert mock_gfs.return_value.add_drive_ro.call_count == retries
+            assert mock_gfs.return_value.shutdown.call_count == retries
+            assert mock_gfs.return_value.close.call_count == retries
+
+    @pytest.mark.parametrize(
+        'disk_path,disk_root', [('/path/to/file.qcow', '/dev/sda')]
+    )
+    def test_guestfs_conn_mount_ro_umount_raises(
+        self, mock_gfs, disk_path, disk_root
+    ):
+        mock_gfs.return_value.umount.side_effect = RuntimeError()
+        with patch('lago.guestfs_tools.find_rootfs') as mock_rootfs:
+            mock_rootfs.return_value = disk_path
+            with pytest.raises(GuestFSError):
+                with guestfs_tools.guestfs_conn_mount_ro(disk_path, disk_root):
+                    pass
+            assert mock_gfs.return_value.umount.call_count == 1
+            assert mock_gfs.return_value.mount_ro.call_count == 1
+
+    @pytest.mark.parametrize(
+        'files,dirs', [
+            (
+                [
+                    ('file_src{0}'.format(idx), 'file_dst{0}'.format(idx))
+                    for idx in range(9)
+                ], [
+                    ('dir_src{0}'.format(idx), 'dir_dst{0}'.format(idx))
+                    for idx in range(9)
+                ]
+            ),
+            ([], [('dir1', 'dirdst1')]),
+            ([('src1', 'dst1')], []),
+            ([], []),
+        ]
+    )
+    def test_extract_paths_files_dirs(self, files, dirs, mock_gfs_fs):
+        def mock_is_file(fname, **kwargs):
+            return len([src for src, _ in files if src == fname]) == 1
+
+        def mock_is_dir(dname, **kwargs):
+            return len([src for src, _ in dirs if src == dname]) == 1
+
+        joined = files + dirs
+        shuffle(joined)
+
+        with patch('lago.guestfs_tools.os.path.isdir') as mock_path_isdir:
+            with patch('lago.guestfs_tools.os.makedirs'):
+                mock_path_isdir.return_value = True
+                mock_gfs_fs.is_file.side_effect = mock_is_file
+                mock_gfs_fs.is_dir.side_effect = mock_is_dir
+                guestfs_tools.extract_paths(
+                    'a', 'b', joined, ignore_nopath=False
+                )
+                assert sorted(mock_path_isdir.mock_calls) == sorted(
+                    [call(host_path) for _, host_path in dirs]
+                )
+
+                assert sorted(mock_gfs_fs.download.mock_calls) == sorted(
+                    [
+                        call(guest_path, host_path)
+                        for guest_path, host_path in files
+                    ]
+                )
+                assert sorted(mock_gfs_fs.copy_out.mock_calls) == sorted(
+                    [
+                        call(guest_path, host_path)
+                        for guest_path, host_path in dirs
+                    ]
+                )
+
+    def test_extract_paths_nodir_created(self, mock_gfs_fs):
+        with patch('lago.guestfs_tools.os.path.isdir') as mock_path_isdir:
+            with patch('lago.guestfs_tools.os.makedirs') as mock_makedirs:
+                mock_path_isdir.return_value = False
+                mock_gfs_fs.is_file.return_value = False
+                mock_gfs_fs.is_dir.return_value = True
+                guestfs_tools.extract_paths(
+                    'a', 'b', [('src-dir', 'dst-dir')], ignore_nopath=False
+                )
+                assert mock_makedirs.mock_calls == [call('dst-dir')]
+
+    def test_extract_paths_file_raises(self, mock_gfs_fs):
+        with patch('lago.guestfs_tools.os.path.isdir') as mock_path_isdir:
+            with patch('lago.guestfs_tools.os.makedirs'):
+                mock_path_isdir.return_value = False
+                mock_gfs_fs.is_file.return_value = True
+                mock_gfs_fs.download.side_effect = RuntimeError('mock')
+                with pytest.raises(GuestFSError):
+                    guestfs_tools.extract_paths(
+                        'a',
+                        'b', [('src-dir', 'dst-dir')],
+                        ignore_nopath=False
+                    )
+
+                assert mock_gfs_fs.download.call_count == 1
+
+    def test_extract_paths_dir_raises(self, mock_gfs_fs):
+        with patch('lago.guestfs_tools.os.path.isdir') as mock_path_isdir:
+            with patch('lago.guestfs_tools.os.makedirs'):
+                mock_path_isdir.return_value = True
+                mock_gfs_fs.is_file.return_value = False
+                mock_gfs_fs.copy_out.side_effect = RuntimeError('mock')
+                with pytest.raises(GuestFSError):
+                    guestfs_tools.extract_paths(
+                        'a',
+                        'b', [('src-dir', 'dst-dir')],
+                        ignore_nopath=False
+                    )
+                assert mock_gfs_fs.copy_out.call_count == 1
+
+    def test_extract_paths_no_file_guest_skipped(self, mock_gfs_fs):
+        with patch('lago.guestfs_tools.os.path.isdir') as mock_path_isdir:
+            with patch('lago.guestfs_tools.os.makedirs'):
+                mock_path_isdir.return_value = False
+                mock_gfs_fs.is_file.return_value = False
+                mock_gfs_fs.is_dir.return_value = False
+                guestfs_tools.extract_paths(
+                    'a', 'b', [('src', 'dst')], ignore_nopath=True
+                )
+                assert mock_gfs_fs.is_file.call_count == 1
+                assert mock_gfs_fs.is_dir.call_count == 1
+
+    def test_extract_paths_no_file_guest_raises(self, mock_gfs_fs):
+        with patch('lago.guestfs_tools.os.path.isdir') as mock_path_isdir:
+            with patch('lago.guestfs_tools.os.makedirs'):
+                mock_path_isdir.return_value = False
+                mock_gfs_fs.is_file.return_value = False
+                mock_gfs_fs.is_dir.return_value = False
+                with pytest.raises(ExtractPathNoPathError):
+                    guestfs_tools.extract_paths(
+                        'a', 'b', [('src', 'dst')], ignore_nopath=False
+                    )
+                assert mock_gfs_fs.is_file.call_count == 1
+                assert mock_gfs_fs.is_dir.call_count == 1


### PR DESCRIPTION
1. Fixed a bug where the exception would not be re-raised after max
attempts exceeded to remount.
2. Changed re-trying logic to restart the connection, as needed.
3. Added a context manager for the guestfs connection, decoupling the
functions.
4. Added unit tests and enhanced the SDK functional tests to use some
randomly generated directories

fixes: https://github.com/lago-project/lago/issues/629


Signed-off-by: Nadav Goldin <ngoldin@redhat.com>