### PR TITLE
Print warning when failed to load plugin

### DIFF
--- a/lago/plugins/__init__.py
+++ b/lago/plugins/__init__.py
@@ -65,7 +65,7 @@ def load_plugins(namespace, instantiate=True):
         namespace=namespace,
         on_load_failure_callback=(
             lambda _, ep, err: LOGGER.
-            debug('Could not load %r: %s', ep.name, err)
+            warning('Could not load plugin {}: {}'.format(ep.name, err))
         )
     )
     if instantiate:


### PR DESCRIPTION
closes https://github.com/lago-project/lago/issues/607

Signed-off-by: gbenhaim <galbh2@gmail.com>