### PR TITLE
Automation: Remove duplicate packages from mock *.packages

### DIFF
--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -5,7 +5,6 @@ dnf-command(builddep)
 git
 grubby
 libffi-devel
-libguestfs-devel
 libvirt-devel
 libguestfs-devel
 libxslt-devel
@@ -13,6 +12,4 @@ openssl-devel
 pandoc
 python2-devel
 python2-dulwich
-python2-virtualenv
-python2-tox
 python-pip

--- a/automation/check-patch.packages.el7
+++ b/automation/check-patch.packages.el7
@@ -4,14 +4,11 @@ git
 libffi-devel
 libguestfs-devel
 libvirt-devel
-libguestfs-devel
 libxslt-devel
 openssl-devel
 pandoc
 python2-devel
 python-dulwich
 python-pip
-python-virtualenv
-python-tox
 yum
 yum-utils


### PR DESCRIPTION
1. libguestfs-devel was twice on the list.
2. virtualenv, and tox are being installed before running the
   tests (using pip).
3. For some reason when installing tox from rpm, entry points aren't
   created, and then the job failed on 'tox: Command not found'. This
   patch will ensure that tox is always installed from PyPi.

Fixes: http://jenkins.ovirt.org/job/lago_master_github_check-patch-fc26-x86_64/216/console

Signed-off-by: gbenhaim <galbh2@gmail.com>