### PR TITLE
Remove strange additions to network settings

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -293,14 +293,9 @@ class Prefix(object):
         Populates the given net spec mapping entry with the nics of the given
         domain, by the following rules:
 
-            * If ``net`` is management, 'domain_name': nic_ip
-            * For each interface: 'domain_name-eth#': nic_ip, where # is the
-            index of the nic in the *domain* definition.
-            * For each interface: 'domain_name-net_name-#': nic_ip,
-            where # is a running number of interfaces from that network.
-            * For each interface: 'domain_name-net_name', which has an
-            identical IP to 'domain_name-net_name-0'
-
+            * If ``idx`` is 0, which is eth0, 'domain_name': nic_ip
+            * For each interface, but eth0: 'domain_name-eth#': nic_ip,
+              where # is the index of the nic in the *domain* definition.
 
         Args:
             net (dict): Network spec to populate
@@ -313,27 +308,11 @@ class Prefix(object):
         """
         dom_name = dom['name']
         idx = dom['nics'].index(nic)
-        name = '{0}-eth{1}'.format(dom_name, idx)
-        net['mapping'][name] = nic['ip']
-        if dom['nics'][idx]['net'] == dom['mgmt_net']:
+        if idx == 0:  # eth0
             net['mapping'][dom_name] = nic['ip']
-
-        name_by_net = '{0}-{1}'.format(dom_name, nic['net'])
-        named_nets = sorted(
-            [
-                net_name for net_name in net['mapping'].keys()
-                if net_name.startswith(name_by_net) and net_name != name_by_net
-            ]
-        )
-
-        if len(named_nets) == 0:
-            named_idx = 0
-            net['mapping'][name_by_net] = nic['ip']
         else:
-            named_idx = len(named_nets)
-        named_net = '{0}-{1}'.format(name_by_net, named_idx)
-
-        net['mapping'][named_net] = nic['ip']
+            name = '{0}-eth{1}'.format(dom_name, idx)
+            net['mapping'][name] = nic['ip']
 
     def _select_mgmt_networks(self, conf):
         """
@@ -434,7 +413,9 @@ class Prefix(object):
                 if not _ip_in_subnet(net['gw'], nic['ip']):
                     raise RuntimeError(
                         "%s:nic%d's IP [%s] is outside the subnet [%s]" % (
-                            dom_name, dom_spec['nics'].index(nic), nic['ip'],
+                            dom_name,
+                            dom_spec['nics'].index(nic),
+                            nic['ip'],
                             net['gw'],
                         ),
                     )
@@ -445,8 +426,11 @@ class Prefix(object):
                         if ip == net['ip']
                     ]
                     raise RuntimeError(
-                        'IP %s was to several domains: %s %s' %
-                        (nic['ip'], dom_name, ' '.join(conflict_list), ),
+                        'IP %s was to several domains: %s %s' % (
+                            nic['ip'],
+                            dom_name,
+                            ' '.join(conflict_list),
+                        ),
                     )
 
                 self._add_nic_to_mapping(net, dom_spec, nic)
@@ -697,7 +681,11 @@ class Prefix(object):
 
     @staticmethod
     def _generate_disk_name(host_name, disk_name, disk_format):
-        return '%s_%s.%s' % (host_name, disk_name, disk_format, )
+        return '%s_%s.%s' % (
+            host_name,
+            disk_name,
+            disk_format,
+        )
 
     def _generate_disk_path(self, disk_name):
         return os.path.expandvars(self.paths.images(disk_name))
@@ -907,9 +895,7 @@ class Prefix(object):
             template_store.download(template_version)
 
         disk_metadata.update(
-            template_store.get_stored_metadata(
-                template_version,
-            ),
+            template_store.get_stored_metadata(template_version, ),
         )
         base = template_store.get_path(template_version)
         qemu_cmd = [
@@ -1606,8 +1592,11 @@ class Prefix(object):
                     LOGGER.debug('STDOUT:\n%s' % out)
                     LOGGER.error('STDERR\n%s' % err)
                     raise RuntimeError(
-                        '%s failed with status %d on %s' %
-                        (script, ret, host.name(), ),
+                        '%s failed with status %d on %s' % (
+                            script,
+                            ret,
+                            host.name(),
+                        ),
                     )
 
     @sdk_utils.expose


### PR DESCRIPTION
We used to have way too many network definitions.
Per network, per network+interface, etc.

For now, only have domain and domain-ethX if X!= 0 (as eth0 is already 'domain')

Tested by running the complete suite of ovirt-system-tests.