### PR TITLE
Small changes to the libvirt XML

### DIFF
--- a/lago/providers/libvirt/templates/dom_template-base.xml.j2
+++ b/lago/providers/libvirt/templates/dom_template-base.xml.j2
@@ -2,9 +2,14 @@
     <name>{{ name }}</name>
     <memory unit='MiB'>{{ mem_size }}</memory>
     <iothreads>1</iothreads>
+    <pm>
+      <suspend-to-disk enabled='no'/>
+      <suspend-to-mem enabled='no'/>
+    </pm>
     <os>
       <type arch='x86_64' machine='pc'>hvm</type>
       <bootmenu enable='no'/>
+      <bios useserial='no'/>
     </os>
     <features>
       <acpi/>
@@ -21,6 +26,7 @@
         <driver name='qemu' type='qcow2'/>
         <source file='DISK_PATH'/>
         <target dev='DISK_DEV' bus='virtio'/>
+        <boot order='1'/>
       </disk>
       <channel type='unix'>
         <source mode='bind'/>

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -568,10 +568,6 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             disk.append(serial)
 
             disk.append(
-                ET.Element('boot', order="{}".format(disk_order + 1)),
-            )
-
-            disk.append(
                 ET.Element(
                     'source',
                     file=os.path.expandvars(dev_spec['path']),


### PR DESCRIPTION
1. Set only the 1st disk as bootable.
2. Don't advertise PM support to the guest - we don't use it anyway.
3. Don't use serial console for boot - we don't use it anyway.