### PR TITLE
collect-artifacts: Try to use Libguestfs

### DIFF
--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -239,7 +239,9 @@ class VMProviderPlugin(plugins.Plugin):
         Raises:
             :exc:`~lago.plugins.vm.ExtractPathNoPathError`: if a none existing
                 path was found on the VM, and ``ignore_nopath`` is True.
-            :exc:`~lago.plugins.vm.ExtractPathError`: on all other failures.
+            :exc:`~lago.plugins.vm.ExtractPathError`: If the vm isn't alive
+                nor ssh reachable.
+            :exc:`~scp.SCPException`: If an error occurred during scp.
         """
         if self.vm.alive() and self.vm.ssh_reachable(
             tries=5, propagate_fail=False

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -29,6 +29,7 @@ import sys
 import libvirt
 from lxml import etree as ET
 from textwrap import dedent
+from scp import SCPException
 
 from lago import export, log_utils, sysprep, utils
 from lago.utils import LagoException
@@ -341,7 +342,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
                 paths=paths,
                 ignore_nopath=ignore_nopath,
             )
-        except ExtractPathError as err:
+        except (ExtractPathError, SCPException) as err:
             LOGGER.debug(
                 '%s: failed extracting files: %s', self.vm.name(), err.message
             )


### PR DESCRIPTION
If an error occurred during SCP try to extract
logs using Libguestfs (if it's available).

Signed-off-by: gbenhaim <galbh2@gmail.com>