### PR TITLE
Set MTU for all interfaces to 9000.

### DIFF
--- a/lago/templates/sysprep-macros.j2
+++ b/lago/templates/sysprep-macros.j2
@@ -13,6 +13,7 @@ chmod 0755:/etc/sysconfig/network-scripts
 	BOOTPROTO="dhcp" \
 	ONBOOT="yes" \
 	TYPE="Ethernet" \
+	MTU="1500" \
 	NAME="{{ iface }}" \
 
 {% endfor %}


### PR DESCRIPTION
This allows us to test with Jumbo frames.
Hopefully, it'll also generally improve performance
(NFS, iSCSI traffic, etc.)

I *think* it won't break if lower libvirt is used.
It won't set the MTU, and ifcfg-* value will be ignored.