### PR TITLE
style: Format code with yapf 0.19

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -12,6 +12,7 @@ indent_width = 4
 join_multiple_lines = true
 spaces_before_comment = 2
 space_between_ending_comma_and_closing_bracket = true
+split_arguments_when_comma_terminated = true
 split_before_bitwise_operator = true
 split_before_logical_operator = true
 split_before_named_assigns = true

--- a/lago/build.py
+++ b/lago/build.py
@@ -175,8 +175,9 @@ class Build(object):
         """
         cmd = ['virt-customize', '-a', self.disk_path]
         if 'ssh-inject' in options and not options['ssh-inject']:
-            options['ssh-inject'
-                    ] = 'root:file:{}'.format(self.paths.ssh_id_rsa_pub())
+            options['ssh-inject'] = 'root:file:{}'.format(
+                self.paths.ssh_id_rsa_pub()
+            )
 
         options = self.normalize_options(options)
         cmd.extend(options)

--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -137,8 +137,9 @@ def do_init(
             'Unable to find init file: {0}'.format(virt_config)
         )
 
-    os.environ['LAGO_INITFILE_PATH'
-               ] = os.path.dirname(os.path.abspath(virt_config))
+    os.environ['LAGO_INITFILE_PATH'] = os.path.dirname(
+        os.path.abspath(virt_config)
+    )
 
     if prefix_name == 'current':
         prefix_name = 'default'
@@ -918,9 +919,7 @@ def main():
             task_tree_depth=args.logdepth,
             level=getattr(logging, args.loglevel.upper()),
             dump_level=logging.ERROR,
-            formatter=log_utils.ColorFormatter(
-                fmt='%(msg)s',
-            )
+            formatter=log_utils.ColorFormatter(fmt='%(msg)s', )
         )
     ]
 

--- a/lago/guestfs_tools.py
+++ b/lago/guestfs_tools.py
@@ -117,8 +117,9 @@ def guestfs_conn_mount_ro(disk_path, disk_root, retries=5, wait=1):
                     continue
                 else:
                     raise GuestFSError(
-                        'failed mounting {0}:{1} using guestfs'.
-                        format(disk_path, rootfs)
+                        'failed mounting {0}:{1} using guestfs'.format(
+                            disk_path, rootfs
+                        )
                     )
             yield conn
             try:
@@ -163,8 +164,9 @@ def find_rootfs(conn, disk_root):
             rootfs = [fs for fs in filesystems.keys() if disk_root in fs]
             if not rootfs:
                 raise GuestFSError(
-                    'no root fs {0} could be found from list {1}'.
-                    format(disk_root, str(filesystems))
+                    'no root fs {0} could be found from list {1}'.format(
+                        disk_root, str(filesystems)
+                    )
                 )
     return sorted(rootfs)[0]
 
@@ -216,8 +218,9 @@ def _copy_path(conn, guest_path, host_path):
         except RuntimeError as err:
             LOGGER.debug(err)
             raise GuestFSError(
-                'failed copying file {0} to {1} using guestfs'.
-                format(guest_path, host_path)
+                'failed copying file {0} to {1} using guestfs'.format(
+                    guest_path, host_path
+                )
             )
     elif conn.is_dir(guest_path, followsymlinks=True):
         if not os.path.isdir(host_path):
@@ -227,8 +230,9 @@ def _copy_path(conn, guest_path, host_path):
         except RuntimeError as err:
             LOGGER.debug(err)
             raise GuestFSError(
-                'failed copying directory {0} to {1} using guestfs'.
-                format(guest_path, host_path)
+                'failed copying directory {0} to {1} using guestfs'.format(
+                    guest_path, host_path
+                )
             )
     else:
         raise ExtractPathNoPathError(

--- a/lago/lago_ansible.py
+++ b/lago/lago_ansible.py
@@ -149,8 +149,9 @@ class LagoAnsible(object):
         temp_file = tempfile.NamedTemporaryFile(mode='r+t')
         inventory = self.get_inventory_str(keys)
         LOGGER.debug(
-            'Writing inventory to temp file {} \n{}'.
-            format(temp_file.name, inventory)
+            'Writing inventory to temp file {} \n{}'.format(
+                temp_file.name, inventory
+            )
         )
         temp_file.write(inventory)
         temp_file.flush()

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -767,7 +767,8 @@ def _resolve_service_class(class_name, service_providers):
     raise plugins.NoSuchPluginError(
         'No service provider plugin with class name %s found, loaded '
         'providers: %s' % (
-            class_name, [
+            class_name,
+            [
                 plugin.__class__.__name__
                 for plugin in service_providers.itervalues()
             ],

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -434,7 +434,9 @@ class Prefix(object):
                 if not _ip_in_subnet(net['gw'], nic['ip']):
                     raise RuntimeError(
                         "%s:nic%d's IP [%s] is outside the subnet [%s]" % (
-                            dom_name, dom_spec['nics'].index(nic), nic['ip'],
+                            dom_name,
+                            dom_spec['nics'].index(nic),
+                            nic['ip'],
                             net['gw'],
                         ),
                     )
@@ -445,8 +447,11 @@ class Prefix(object):
                         if ip == net['ip']
                     ]
                     raise RuntimeError(
-                        'IP %s was to several domains: %s %s' %
-                        (nic['ip'], dom_name, ' '.join(conflict_list), ),
+                        'IP %s was to several domains: %s %s' % (
+                            nic['ip'],
+                            dom_name,
+                            ' '.join(conflict_list),
+                        ),
                     )
 
                 self._add_nic_to_mapping(net, dom_spec, nic)
@@ -697,7 +702,11 @@ class Prefix(object):
 
     @staticmethod
     def _generate_disk_name(host_name, disk_name, disk_format):
-        return '%s_%s.%s' % (host_name, disk_name, disk_format, )
+        return '%s_%s.%s' % (
+            host_name,
+            disk_name,
+            disk_format,
+        )
 
     def _generate_disk_path(self, disk_name):
         return os.path.expandvars(self.paths.images(disk_name))
@@ -1606,8 +1615,11 @@ class Prefix(object):
                     LOGGER.debug('STDOUT:\n%s' % out)
                     LOGGER.error('STDERR\n%s' % err)
                     raise RuntimeError(
-                        '%s failed with status %d on %s' %
-                        (script, ret, host.name(), ),
+                        '%s failed with status %d on %s' % (
+                            script,
+                            ret,
+                            host.name(),
+                        ),
                     )
 
     @sdk_utils.expose

--- a/lago/providers/libvirt/network.py
+++ b/lago/providers/libvirt/network.py
@@ -276,8 +276,9 @@ class NATNetwork(Network):
                 net_xml.append(dns)
 
         LOGGER.debug(
-            'Generated Network XML\n {0}'.
-            format(ET.tostring(net_xml, pretty_print=True))
+            'Generated Network XML\n {0}'.format(
+                ET.tostring(net_xml, pretty_print=True)
+            )
         )
         return ET.tostring(net_xml)
 

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -160,9 +160,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
         if self.defined():
             self.vm._ssh_client = None
             with LogTask('Destroying VM %s' % self.vm.name()):
-                self.libvirt_con.lookupByName(
-                    self._libvirt_name(),
-                ).destroy()
+                self.libvirt_con.lookupByName(self._libvirt_name(), ).destroy()
 
     def shutdown(self, *args, **kwargs):
         super().shutdown(*args, **kwargs)
@@ -446,9 +444,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             "console",
             self._libvirt_name(),
         ]
-        return utils.run_interactive_command(
-            command=virsh_command,
-        )
+        return utils.run_interactive_command(command=virsh_command, )
 
     @property
     def cpu_model(self):

--- a/lago/ssh.py
+++ b/lago/ssh.py
@@ -329,9 +329,7 @@ def get_ssh_client(
 
         start_time = time.time()
         client = paramiko.SSHClient()
-        client.set_missing_host_key_policy(
-            paramiko.AutoAddPolicy(),
-        )
+        client.set_missing_host_key_policy(paramiko.AutoAddPolicy(), )
         while ssh_tries > 0:
             LOGGER.debug(
                 'Still got %d tries for %s',

--- a/lago/sysprep.py
+++ b/lago/sysprep.py
@@ -102,7 +102,9 @@ def sysprep(disk, distro, loader=None, backend='direct', **kwargs):
     if ret:
         raise RuntimeError(
             'Failed to bootstrap %s\ncommand:%s\nstdout:%s\nstderr:%s' % (
-                disk, ' '.join('"%s"' % elem for elem in cmd), ret.out,
+                disk,
+                ' '.join('"%s"' % elem for elem in cmd),
+                ret.out,
                 ret.err,
             )
         )

--- a/lago/templates.py
+++ b/lago/templates.py
@@ -274,14 +274,12 @@ def find_repo_by_name(name, repo_dir=None):
     if repo_dir is None:
         repo_dir = config.get('template_repos')
 
-    ret, out, _ = utils.run_command(
-        [
-            'find',
-            repo_dir,
-            '-name',
-            '*.json',
-        ],
-    )
+    ret, out, _ = utils.run_command([
+        'find',
+        repo_dir,
+        '-name',
+        '*.json',
+    ], )
 
     repos = [
         TemplateRepository.from_url(line.strip()) for line in out.split('\n')
@@ -650,8 +648,10 @@ class TemplateStore:
             sha1 = utils.get_hash(temp_dest)
             if temp_ver.get_hash() != sha1:
                 raise RuntimeError(
-                    'Image %s does not match the expected hash %s' %
-                    (temp_ver.name, sha1.hexdigest(), )
+                    'Image %s does not match the expected hash %s' % (
+                        temp_ver.name,
+                        sha1.hexdigest(),
+                    )
                 )
 
             with open('%s.hash' % dest, 'w') as f:

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -515,8 +515,9 @@ def with_logging(func):
 
 
 def add_timestamp_suffix(base_string):
-    return datetime.datetime.fromtimestamp(time.time(
-    )).strftime(base_string + '.%Y-%m-%d_%H:%M:%S')
+    return datetime.datetime.fromtimestamp(
+        time.time()
+    ).strftime(base_string + '.%Y-%m-%d_%H:%M:%S')
 
 
 def rotate_dir(base_dir):

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -111,8 +111,9 @@ class VirtEnv(object):
             vm_type = self.vm_types[vm_type_name]
         except KeyError:
             raise RuntimeError(
-                'Unknown VM type: {0}, available types: {1}'.
-                format(vm_type_name, ','.join(self.vm_types.keys()))
+                'Unknown VM type: {0}, available types: {1}'.format(
+                    vm_type_name, ','.join(self.vm_types.keys())
+                )
             )
         vm_spec['vm-type'] = vm_type_name
         return vm_type(self, vm_spec)
@@ -193,8 +194,9 @@ class VirtEnv(object):
 
         if running_vms:
             raise utils.LagoUserException(
-                'The following vms must be off:\n{}'.
-                format('\n'.join([_vm.name() for _vm in running_vms]))
+                'The following vms must be off:\n{}'.format(
+                    '\n'.join([_vm.name() for _vm in running_vms])
+                )
             )
 
         with LogTask('Exporting disks to: {}'.format(dst_dir)):
@@ -478,8 +480,9 @@ class VirtEnv(object):
 
         if missing_vms:
             raise utils.LagoUserException(
-                'The following vms do not exist: \n{}'.
-                format('\n'.join(missing_vms))
+                'The following vms do not exist: \n{}'.format(
+                    '\n'.join(missing_vms)
+                )
             )
 
         return vms

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ packages =
 
 [flake8]
 # ignore line break before operator
-ignore = W503
+ignore = W503,E722
 exclude = */*venv/*,automation-build,rpmbuild,dist,tests/functional,.eggs
 
 [package_data]


### PR DESCRIPTION
1. Latest releases of yapf (specifically 0.17) introduced some bug
   fixes which effect the formatting of the code. In this commit the
   code is reformatted with the latest version of yapf.

2. Added a new style rule: each list of arguments which is bigger than 1
   and ended with a comma will be split into multiple lines.

Signed-off-by: gbenhaim <galbh2@gmail.com>