### PR TITLE
Set MTU per interface.

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -502,6 +502,24 @@ class Prefix(object):
                 nic['ip'] = vacant
                 self._add_nic_to_mapping(net, dom_spec, nic)
 
+    def _set_mtu_to_nics(self, conf):
+        """
+        For all the nics of all the domains in the conf that have MTU set,
+        save the MTU on the NIC definition.
+
+        Args:
+            conf (dict): Configuration spec to extract the domains from
+
+        Returns:
+            None
+        """
+        for dom_name, dom_spec in conf.get('domains', {}).items():
+            for idx, nic in enumerate(dom_spec.get('nics', [])):
+                net = self._get_net(conf, dom_name, nic)
+                mtu = net.get('mtu', 1500)
+                if mtu != 1500:
+                    nic['mtu'] = mtu
+
     def _config_net_topology(self, conf):
         """
         Initialize and populate all the network related elements, like
@@ -522,6 +540,7 @@ class Prefix(object):
             self._add_mgmt_to_domains(conf, mgmts)
             self._register_preallocated_ips(conf)
             self._allocate_ips_to_nics(conf)
+            self._set_mtu_to_nics(conf)
             self._add_dns_records(conf, mgmts)
         except:
             self._subnet_store.release(allocated_subnets)

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -461,13 +461,15 @@ class Prefix(object):
             net = conf['nets'][nic['net']]
         except KeyError:
             raise LagoInitException(
-                (
-                    'Unrecognized network in {0}: '
-                    '{1}, available: '
-                    '{2}'
-                ).format(
-                    dom_name, nic['net'],
-                    ','.join(conf.get('nets', {}).keys())
+                dedent(
+                    """
+                    Unrecognized network in {0}: {1},
+                    available: {2}
+                    """.format(
+                        dom_name,
+                        nic['net'],
+                        ','.join(conf.get('nets', {}).keys()),
+                    )
                 )
             )
 
@@ -1640,5 +1642,6 @@ class Prefix(object):
     @log_task('Deploy environment')
     def deploy(self):
         utils.invoke_in_parallel(
-            self._deploy_host, self.virt_env.get_vms().values()
+            self._deploy_host,
+            self.virt_env.get_vms().values()
         )

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -601,6 +601,13 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
                     type='virtio',
                 ),
             )
+            if self._libvirt_ver > 3001001:
+                mtu = dev_spec.get('mtu', '1500')
+                if mtu != '1500':
+                    interface.append(ET.Element(
+                        'mtu',
+                        size=str(mtu),
+                    ))
             if 'ip' in dev_spec:
                 interface.append(
                     ET.Element(

--- a/tests/unit/lago/test_prefix.py
+++ b/tests/unit/lago/test_prefix.py
@@ -173,8 +173,10 @@ class TestPrefixNetworkInitalization(object):
                     'nets': {
                         'mgmt': {}
                     }
-                },
-                ('Unrecognized NIC: does_not_exist, configured for VM: vm-01')
+                }, (
+                    r'Unrecognized network in vm-01: does_not_exist,\n'
+                    'available: mgmt'
+                )
             ),
             (
                 {


### PR DESCRIPTION
Apparently, it's not enough to set it for the network.
It needs to be set up per the interface as well.
For example:
    nics:
      - net: lago-{{ env.suite_name}}-net-management
      - net: lago-{{ env.suite_name}}-net-storage
        mtu: 9000

Would set MTU 9000 to net-storage.

(It should match the network too!)