### PR TITLE
Use libvirt filesystem share with VMs for RPMs

### DIFF
--- a/lago/providers/libvirt/templates/dom_template-base.xml.j2
+++ b/lago/providers/libvirt/templates/dom_template-base.xml.j2
@@ -49,4 +49,10 @@
       <timer name='kvmclock'>
       </timer>
     </clock>
+    <filesystem type='mount' accessmode='mapped'>                                
+     <source dir='/var/lib/lago/reposync/'/>                               
+     <target dir='/vm_data/yum-repos/'/>                                        
+     <readonly/>                                                                
+     <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
+   </filesystem>                                                                
 </domain>

--- a/lago/providers/libvirt/templates/dom_template-el6.xml.j2
+++ b/lago/providers/libvirt/templates/dom_template-el6.xml.j2
@@ -46,4 +46,10 @@
       <timer name='kvmclock'>
       </timer>
     </clock>
+    <filesystem type='mount' accessmode='mapped'>
+      <source dir='/var/lib/lago/reposync/'/>
+      <target dir='/vm_data/yum-repos/'/>
+      <readonly/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x08' function='0x0'/>
+    </filesystem> 
 </domain>


### PR DESCRIPTION
Use 'filesystem' directive to share reposync with the VMs eliminating
the need for the slow http server.

- The mount will be read-only.
- RHL/Centos VMs should auto mount this directory, if
not, needs manual mounting in the deploy scripts

Signed-off-by: Roy Golan <rgolan@redhat.com>