### PR TITLE
sdk_tests: Check that VM is running

### DIFF
--- a/tests/functional-sdk/test_sdk_sanity.py
+++ b/tests/functional-sdk/test_sdk_sanity.py
@@ -171,6 +171,12 @@ def test_custom_gateway(vms, nets, init_dict):
             assert nets[net_name].gw() == net['gw']
 
 
+def test_vm_is_running(vms, vm_name):
+    vm = vms[vm_name]
+    assert vm.defined()
+    assert vm.state() == 'running'
+
+
 def test_vms_ssh(vms, vm_name):
     vm = vms[vm_name]
     assert vm.ssh_reachable(tries=200)


### PR DESCRIPTION
Add a test for checking if a VM is running.
Make sense to verify that the VMs are running before
testing ssh.

Signed-off-by: gbenhaim <galbh2@gmail.com>