### PR TITLE
deploy: Don't propagate fail when waiting for ssh

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -1621,7 +1621,7 @@ class Prefix(object):
                 return
 
             with LogTask('Wait for ssh connectivity'):
-                if not host.ssh_reachable(tries=1):
+                if not host.ssh_reachable(tries=1, propagate_fail=False):
                     time.sleep(10)
                     host.wait_for_ssh()
 


### PR DESCRIPTION
This commit is part of 167d99a.
Without it, if host.ssh_reachable() is false, the outer log
task will always be marked as a failure.

Signed-off-by: gbenhaim <galbh2@gmail.com>