### PR TITLE
sysprep: Remove could-init

### DIFF
--- a/lago/templates/sysprep-base.j2
+++ b/lago/templates/sysprep-base.j2
@@ -10,3 +10,5 @@ upload {{ public_key }}:/root/.ssh/authorized_keys
 chmod 0600:/root/.ssh/authorized_keys
 run-command chown root:root /root/.ssh/authorized_keys
 {% endif -%}
+mkdir /etc/cloud
+touch /etc/cloud/cloud-init.disabled


### PR DESCRIPTION
This change improves the usage of cloud images in lago.
If we think the usage of [generic cloud images in OST](https://gerrit.ovirt.org/#/c/85170/) would be a good idea, this change would prepare this.