### PR TITLE
prefix: Expose Paths object in the SDK

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -227,12 +227,13 @@ def do_cleanup(prefix, **kwargs):
 def do_destroy(
     prefix, yes, all_prefixes, parent_workdir, prefix_name, **kwargs
 ):
-    warn_message = prefix.paths.prefix
-    path = prefix.paths.prefix
 
     if all_prefixes:
         warn_message = 'all the prefixes under ' + parent_workdir.path
         path = parent_workdir.path
+    else:
+        warn_message = prefix.paths.prefix_path()
+        path = warn_message
 
     if not yes:
         response = raw_input(
@@ -575,7 +576,7 @@ def do_status(prefix, out_format, **kwargs):
         'Prefix':
             {
                 'Base directory':
-                    prefix.paths.prefix,
+                    prefix.paths.prefix_path(),
                 'UUID':
                     uuid,
                 'Networks':

--- a/lago/paths.py
+++ b/lago/paths.py
@@ -21,11 +21,26 @@ import os
 
 
 class Paths(object):
-    def __init__(self, prefix):
-        self.prefix = prefix
+    """
+    A Paths object contains methods for getting the paths to the
+    directories and files which composes the prefix.
+
+    Attributes:
+        _prefix_path (str): Path to the directory of the prefix
+    """
+
+    def __init__(self, prefix_path):
+        """
+        Args:
+            prefix_path (str): Path to the directory of the prefix
+        """
+        self._prefix_path = prefix_path
 
     def prefixed(self, *args):
-        return os.path.join(self.prefix, *args)
+        return os.path.join(self._prefix_path, *args)
+
+    def prefix_path(self):
+        return self._prefix_path
 
     def uuid(self):
         return self.prefixed('uuid')


### PR DESCRIPTION
- Expose Paths object in the SDK (currently, we can only expose methods,
  not properties).

- Expose the paths attribute as a property (for internal use inside lago).

- Added some documentation about the Paths class.

- In Prefix class, change the attribute name that contains the prefix path from
  "prefix" to "prefix_path" (the convention in our code is that a variable
  named "prefix" is a Prefix object).

- Remove "_prefix" attribute from the prefix object. This attribute
  used to hold the path to the prefix, but the same value is also stored
  in the Paths object, so there is no reason to save it twice.