### PR TITLE
style: Control manually on yapf version

### DIFF
--- a/test-requires.txt
+++ b/test-requires.txt
@@ -4,7 +4,7 @@ flake8
 mock
 futures
 xmlunittest
-yapf
+yapf==0.20
 pytest
 pytest-cov
 pytest-timeout


### PR DESCRIPTION
- It will save us to format the entire code base every couple
  of month when a new version of yapf is released.

- Pin yapf to version 0.20

Signed-off-by: gbenhaim <galbh2@gmail.com>