### PR TITLE
docs: Mock future lib

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,7 @@ autodoc_mock_imports = [
     'xmltodict',
     'wrapt',
     'netaddr',
+    'future',
 ]
 
 autodoc_default_flags = [


### PR DESCRIPTION
Mock future lib when building the docs.
This way sphinx will not complain that it's missing.

Signed-off-by: gbenhaim <galbh2@gmail.com>