### PR TITLE
Paths

### DIFF
--- a/lago/paths.py
+++ b/lago/paths.py
@@ -34,6 +34,8 @@ class Paths(object):
         Args:
             prefix_path (str): Path to the directory of the prefix
         """
+        # self._prefix should be dropped in lago ver 0.44
+        self.prefix = prefix_path
         self._prefix_path = prefix_path
 
     def prefixed(self, *args):

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -106,6 +106,8 @@ class Prefix(object):
         Args:
             prefix (str): Path of the prefix
         """
+        # self._prefix should be dropped in lago ver 0.44
+        self._prefix = prefix
         self._paths = paths.Paths(prefix)
         self._virt_env = None
         self._metadata = None
@@ -1402,6 +1404,10 @@ class Prefix(object):
     @property
     def paths(self):
         return self._paths
+
+    @paths.setter
+    def paths(self, val):
+        self._paths = val
 
     def destroy(self):
         """


### PR DESCRIPTION
6eda019 fixed the api of
the Paths object. This change can break lago-ovirt which uses the old
api.

For the meanwhile, adding back the old variables. Once a new version
of lago will be released, we can adopt the new api in lago-ovirt.

Signed-off-by: gbenhaim <galbh2@gmail.com>