### PR TITLE
brctl: Use "ip" to check if a bridge exists

### DIFF
--- a/lago/brctl.py
+++ b/lago/brctl.py
@@ -56,5 +56,14 @@ def destroy(name):
 
 
 def exists(name):
-    ret, out, err = _brctl('show', name)
-    return err == ''
+    ret, out, _ = utils.run_command(
+        ['ip', '-o', 'link', 'show', 'type', 'bridge']
+    )
+    if ret:
+        raise RuntimeError('Failed to check if bridge {} exists'.format(name))
+
+    for entry in out.splitlines():
+        if name == entry.split(':')[1].strip():
+            return True
+
+    return False


### PR DESCRIPTION
The interface of "brctl" was changed in fc27.
When calling "brctl show X", if X doesn't exists,
the return code is non-zero. In order to overcome this issue,
check if the bridge exists using "ip" command.

Signed-off-by: gbenhaim <galbh2@gmail.com>