### PR TITLE
Reuse libvirt connections

### DIFF
--- a/lago/providers/libvirt/network.py
+++ b/lago/providers/libvirt/network.py
@@ -27,17 +27,25 @@ from copy import deepcopy
 from lxml import etree as ET
 import lago.providers.libvirt.utils as libvirt_utils
 from lago import brctl, log_utils, utils
+from lago.config import config
 
 LOGGER = logging.getLogger(__name__)
 LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
 
 
 class Network(object):
-    def __init__(self, env, spec, compat, libvirt_con):
+    def __init__(self, env, spec, compat):
         self._env = env
-        self.libvirt_con = libvirt_con
         self._spec = spec
         self.compat = compat
+
+        libvirt_url = config.get('libvirt_url')
+        self.libvirt_con = libvirt_utils.get_libvirt_connection()
+
+    def __del__(self):
+        if self.libvirt_con is not None:
+            libvirt_utils.close_libvirt_connection()
+            self.libvirt_con = None
 
     def name(self):
         return self._spec['name']

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -475,24 +475,6 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
     def _libvirt_name(self):
         return self.vm.virt_env.prefixed_name(self.vm.name())
 
-    def _get_qemu_kvm_path(self):
-        qemu_kvm_path = self._caps.findtext(
-            "guest[os_type='hvm']/arch[@name='x86_64']/domain[@type='kvm']"
-            "/emulator"
-        )
-
-        if not qemu_kvm_path:
-            LOGGER.warning("hardware acceleration not available")
-            qemu_kvm_path = self._caps.findtext(
-                "guest[os_type='hvm']/arch[@name='x86_64']"
-                "/domain[@type='qemu']/../emulator"
-            )
-
-        if not qemu_kvm_path:
-            raise utils.LagoException('kvm executable not found')
-
-        return qemu_kvm_path
-
     def _load_xml(self):
 
         args = {
@@ -500,7 +482,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             'libvirt_ver': self._libvirt_ver,
             'name': self._libvirt_name(),
             'mem_size': self.vm.spec.get('memory', 16 * 1024),
-            'qemu_kvm': self._get_qemu_kvm_path()
+            'qemu_kvm': libvirt_utils.get_qemu_kvm_path()
         }
 
         dom_raw_xml = libvirt_utils.get_domain_template(**args)

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -56,7 +56,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
         self._has_guestfs = 'lago.guestfs_tools' in sys.modules
         libvirt_url = config.get('libvirt_url')
         self.libvirt_con = libvirt_utils.get_libvirt_connection(
-            libvirt_url=libvirt_url,
+            libvirt_url=libvirt_url
         )
         self._libvirt_ver = libvirt_utils.get_libvirt_version()
 
@@ -458,8 +458,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             str: CPU model
 
         """
-        self.cpu()
-        return self.cpu.model
+        return self.cpu().model
 
     @property
     def cpu_vendor(self):
@@ -469,8 +468,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
         Returns:
             str: CPU vendor
         """
-        self.cpu()
-        return self.cpu.vendor
+        return self.cpu().vendor
 
     def _libvirt_name(self):
         return self.vm.virt_env.prefixed_name(self.vm.name())


### PR DESCRIPTION
1. For some reason, we've opened many connections to libvirt.
A single libvirt connection should suffice.
2. Every connection (for VM) would do a getCapabilities and
getVersion - for no reason - reuse from the same one.
3. We've never really bothered to try and close the connections.
I don't think I've closed all connections, but I've made an honest
effort.
4. As consequence, we do not generate the CPU (and NUMA config) so many times (this is what started this whole patch).
