### PR TITLE
SDK functional move fixtures and update images

### DIFF
--- a/tests/functional-sdk/conftest.py
+++ b/tests/functional-sdk/conftest.py
@@ -1,6 +1,10 @@
 import os
 import pytest
 import shutil
+from lago_fixtures import (  # noqa: F401
+    tmp_workdir, init_dict, init_fname, test_results,
+    external_log, env, vms, nets
+)
 
 _local_config = {
     'check_patch': {
@@ -61,9 +65,3 @@ def global_test_results():
         shutil.rmtree(workdir)
     os.makedirs(workdir)
     return str(workdir)
-
-
-@pytest.fixture(scope='module')
-def tmp_workdir(tmpdir_factory):
-    env_workdir = tmpdir_factory.mktemp('env')
-    return env_workdir

--- a/tests/functional-sdk/conftest.py
+++ b/tests/functional-sdk/conftest.py
@@ -10,8 +10,8 @@ _local_config = {
         {
             'images':
                 [
-                    'el7.4-base', 'el6-base', 'fc25-base', 'fc26-base',
-                    'fc27-base', 'ubuntu16.04-base', 'debian8-base'
+                    'el7.4-base-1', 'el6-base', 'fc26-base', 'fc27-base',
+                    'ubuntu16.04-base', 'debian8-base'
                 ]
         }  # noqa: E123
 }

--- a/tests/functional-sdk/lago_fixtures.py
+++ b/tests/functional-sdk/lago_fixtures.py
@@ -1,0 +1,73 @@
+import logging
+import os
+import shutil
+import tempfile
+import pytest
+import yaml
+from lago import sdk
+
+
+@pytest.fixture(scope='module')
+def tmp_workdir(tmpdir_factory):
+    env_workdir = tmpdir_factory.mktemp('env')
+    return env_workdir
+
+
+@pytest.fixture(scope='module')
+def init_dict(init_str):
+    return yaml.load(init_str)
+
+
+@pytest.fixture(scope='module')
+def init_fname(init_str):
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(init_str)
+    return f.name
+
+
+@pytest.fixture(scope='module')
+def test_results(request, global_test_results):
+    results_path = os.path.join(
+        global_test_results, str(request.module.__name__)
+    )
+    os.makedirs(results_path)
+    return results_path
+
+
+@pytest.fixture(scope='module')
+def external_log(tmpdir_factory):
+    return tmpdir_factory.mktemp('external_log').join('custom_log.log')
+
+
+@pytest.fixture(scope='module', autouse=True)
+def env(request, init_fname, test_results, tmp_workdir, external_log):
+    workdir = os.path.join(str(tmp_workdir), 'lago')
+    env = sdk.init(
+        init_fname,
+        workdir=workdir,
+        logfile=str(external_log),
+        loglevel=logging.DEBUG,
+    )
+    env.start()
+    try:
+        yield env
+        collect_path = os.path.join(test_results, 'collect')
+        env.collect_artifacts(output_dir=collect_path, ignore_nopath=True)
+        shutil.copytree(
+            workdir,
+            os.path.join(test_results, 'workdir'),
+            ignore=shutil.ignore_patterns('*images*')
+        )
+    finally:
+        env.stop()
+        env.destroy()
+
+
+@pytest.fixture(scope='module')
+def vms(env):
+    return env.get_vms()
+
+
+@pytest.fixture(scope='module')
+def nets(env):
+    return env.get_nets()

--- a/tests/functional-sdk/test_sdk_sanity.py
+++ b/tests/functional-sdk/test_sdk_sanity.py
@@ -1,9 +1,7 @@
 import pytest
-import yaml
 import textwrap
 import tempfile
 import os
-import shutil
 import logging
 import uuid
 import filecmp
@@ -11,7 +9,6 @@ from jinja2 import Environment, BaseLoader
 from lago import sdk
 from lago.utils import run_command
 from lago.plugins.vm import ExtractPathNoPathError
-
 from utils import RandomizedDir
 
 
@@ -67,66 +64,6 @@ def init_str(images):
     )
     template = Environment(loader=BaseLoader()).from_string(init_template)
     return template.render(images=images)
-
-
-@pytest.fixture(scope='module')
-def init_dict(init_str):
-    return yaml.load(init_str)
-
-
-@pytest.fixture(scope='module')
-def init_fname(init_str):
-    with tempfile.NamedTemporaryFile(delete=False) as f:
-        f.write(init_str)
-    return f.name
-
-
-@pytest.fixture(scope='module')
-def test_results(request, global_test_results):
-    results_path = os.path.join(
-        global_test_results, str(request.module.__name__)
-    )
-    os.makedirs(results_path)
-    return results_path
-
-
-@pytest.fixture(scope='module')
-def external_log(tmpdir_factory):
-    return tmpdir_factory.mktemp('external_log').join('custom_log.log')
-
-
-@pytest.fixture(scope='module', autouse=True)
-def env(request, init_fname, test_results, tmp_workdir, external_log):
-    workdir = os.path.join(str(tmp_workdir), 'lago')
-    env = sdk.init(
-        init_fname,
-        workdir=workdir,
-        logfile=str(external_log),
-        loglevel=logging.DEBUG,
-    )
-    env.start()
-    try:
-        yield env
-        collect_path = os.path.join(test_results, 'collect')
-        env.collect_artifacts(output_dir=collect_path, ignore_nopath=True)
-        shutil.copytree(
-            workdir,
-            os.path.join(test_results, 'workdir'),
-            ignore=shutil.ignore_patterns('*images*')
-        )
-    finally:
-        env.stop()
-        env.destroy()
-
-
-@pytest.fixture(scope='module')
-def vms(env):
-    return env.get_vms()
-
-
-@pytest.fixture(scope='module')
-def nets(env):
-    return env.get_nets()
 
 
 @pytest.fixture


### PR DESCRIPTION
sdk-tests: Update the test's images
- We have a new image of el7.4
- fc25 is obsolete

sdk-tests: Move Lago's fixtures to an external module
This way Lago's fixtures can be shared across different
test modules.