### PR TITLE
libvirt calls cleanup

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -456,7 +456,7 @@ def do_shell(prefix, host, args=None, **kwargs):
             )
             raise
 
-    if not host.alive():
+    if not host.running():
         raise RuntimeError(
             'Host %s is not "running", but "%s"' % (host.name(), host.state())
         )
@@ -679,7 +679,7 @@ def do_copy_from_vm(prefix, host, remote_path, local_path, **kwargs):
         )
         raise
 
-    if not host.alive():
+    if not host.running():
         raise RuntimeError(
             'Host %s is not "running", but "%s"' % (host.name(), host.state())
         )
@@ -719,7 +719,7 @@ def do_copy_to_vm(prefix, host, remote_path, local_path, **kwargs):
         )
         raise
 
-    if not host.alive():
+    if not host.running():
         raise RuntimeError(
             'Host %s is not "running", but "%s"' % (host.name(), host.state())
         )

--- a/lago/providers/libvirt/network.py
+++ b/lago/providers/libvirt/network.py
@@ -86,9 +86,8 @@ class Network(object):
         )
 
     def alive(self):
-        flags = libvirt.VIR_CONNECT_LIST_NETWORKS_ACTIVE \
-            | libvirt.VIR_CONNECT_LIST_NETWORKS_TRANSIENT \
-            | libvirt.VIR_CONNECT_LIST_NETWORKS_NO_AUTOSTART
+        flags = libvirt.VIR_CONNECT_LIST_NETWORKS_TRANSIENT \
+            | libvirt.VIR_CONNECT_LIST_NETWORKS_ACTIVE
         net_names = [
             net.name() for net in self.libvirt_con.listAllNetworks(flags)
         ]

--- a/lago/providers/libvirt/network.py
+++ b/lago/providers/libvirt/network.py
@@ -27,7 +27,7 @@ from copy import deepcopy
 from lxml import etree as ET
 import lago.providers.libvirt.utils as libvirt_utils
 from lago import brctl, log_utils, utils
-from lago.config import config
+import libvirt
 
 LOGGER = logging.getLogger(__name__)
 LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
@@ -36,10 +36,8 @@ LogTask = functools.partial(log_utils.LogTask, logger=LOGGER)
 class Network(object):
     def __init__(self, env, spec, compat):
         self._env = env
-        libvirt_url = config.get('libvirt_url')
         self.libvirt_con = libvirt_utils.get_libvirt_connection(
-            name=env.uuid + libvirt_url,
-            libvirt_url=libvirt_url,
+            name=env.uuid,
         )
         self._spec = spec
         self.compat = compat
@@ -88,7 +86,12 @@ class Network(object):
         )
 
     def alive(self):
-        net_names = [net.name() for net in self.libvirt_con.listAllNetworks()]
+        flags = libvirt.VIR_CONNECT_LIST_NETWORKS_ACTIVE \
+            | libvirt.VIR_CONNECT_LIST_NETWORKS_TRANSIENT \
+            | libvirt.VIR_CONNECT_LIST_NETWORKS_NO_AUTOSTART
+        net_names = [
+            net.name() for net in self.libvirt_con.listAllNetworks(flags)
+        ]
         return self._libvirt_name() in net_names
 
     def start(self, attempts=5, timeout=2):

--- a/lago/providers/libvirt/utils.py
+++ b/lago/providers/libvirt/utils.py
@@ -77,12 +77,13 @@ def auth_callback(credentials, user_data):
     return 0
 
 
-def get_libvirt_connection(name, libvirt_url='qemu:///system'):
+def get_libvirt_connection(name):
     if name not in LIBVIRT_CONNECTIONS:
         auth = [
             [libvirt.VIR_CRED_AUTHNAME, libvirt.VIR_CRED_PASSPHRASE],
             auth_callback, None
         ]
+        libvirt_url = config.get('libvirt_url', 'qemu:///system')
 
         LIBVIRT_CONNECTIONS[name] = libvirt.openAuth(libvirt_url, auth)
 

--- a/lago/providers/libvirt/utils.py
+++ b/lago/providers/libvirt/utils.py
@@ -67,6 +67,10 @@ class Domain(object):
         return DOMAIN_STATES.get(state_number[0], 'unknown')
 
 
+def libvirt_callback(userdata, err):
+    pass
+
+
 def auth_callback(credentials, user_data):
     for credential in credentials:
         if credential[0] == libvirt.VIR_CRED_AUTHNAME:
@@ -85,6 +89,7 @@ def get_libvirt_connection(name):
         ]
         libvirt_url = config.get('libvirt_url', 'qemu:///system')
 
+        libvirt.registerErrorHandler(f=libvirt_callback, ctx=None)
         LIBVIRT_CONNECTIONS[name] = libvirt.openAuth(libvirt_url, auth)
 
     return LIBVIRT_CONNECTIONS[name]

--- a/lago/virt.py
+++ b/lago/virt.py
@@ -179,7 +179,7 @@ class VirtEnv(object):
                 vm = self._vms[name]
                 if not vm.spec.get('skip-export'):
                     vms.append(vm)
-                    if vm.defined():
+                    if vm.running():
                         running_vms.append(vm)
             except KeyError:
                 raise utils.LagoUserException(
@@ -393,7 +393,7 @@ class VirtEnv(object):
         for vm in vms_to_stop:
             unused_nets = unused_nets.union(vm.nets())
         for vm in self._vms.values():
-            if not vm.defined() or vm.name() in vm_names:
+            if not vm.running() or vm.name() in vm_names:
                 continue
             for net in vm.nets():
                 unused_nets.discard(net)

--- a/tests/functional-sdk/test_sdk_sanity.py
+++ b/tests/functional-sdk/test_sdk_sanity.py
@@ -110,7 +110,7 @@ def test_custom_gateway(vms, nets, init_dict):
 
 def test_vm_is_running(vms, vm_name):
     vm = vms[vm_name]
-    assert vm.defined()
+    assert vm.running()
     assert vm.state() == 'running'
 
 


### PR DESCRIPTION
Less calls (hopefully) to libvirt, more specific lookups for VMs
and networks.
A bit of cleanup - remove of libvirt related stuff from lago/virt.py