### PR TITLE
Reduce the number of DHCP entries we add to libvirt.

### DIFF
--- a/lago/providers/libvirt/network.py
+++ b/lago/providers/libvirt/network.py
@@ -226,7 +226,13 @@ class NATNetwork(Network):
                 )
             )
 
-            for hostname, ip4 in self._spec['mapping'].items():
+            ipv4s = []
+            for hostname in sorted(self._spec['mapping'].iterkeys()):
+                ip4 = self._spec['mapping'][hostname]
+                if ip4 in ipv4s:
+                    continue
+
+                ipv4s.append(ip4)
                 dhcp.append(
                     ET.Element(
                         'host',


### PR DESCRIPTION
We only need really one entry per host.
The fact a host has many DNS names (X-eth..., X-<network-name>, etc...)
doesn't mean we need so many DHCP entries.