### PR TITLE
cli-functional-tests: Don't use lago's group

### DIFF
--- a/automation/common.sh
+++ b/automation/common.sh
@@ -124,7 +124,7 @@ run_functional_cli_tests() {
     local tests
     tests=("$@")
     pushd tests/functional
-    sg lago -c "bats ${tests[*]} " | tee functional_tests.tap
+    bats "${tests[@]}" | tee functional_tests.tap
     res=${PIPESTATUS[0]}
     popd
     return "$res"


### PR DESCRIPTION
Up until now we used to trigger lago's functional tests with the lago
group.

This can cause an issue if the lago group doesn't exist on the host that
runs the mock. Also, this is not really testing anything, since we run as
root inside the mock.

In order to test the creation of the lago group, tests can be run in
"lago-demo" repository, which uses VMs for running the tests.

Signed-off-by: gbenhaim <galbh2@gmail.com>