### PR TITLE
Don't use check_alive decorator in ssh_reachable

### DIFF
--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -542,7 +542,6 @@ class VMPlugin(plugins.Plugin):
     def alive(self):
         return self.state() == 'running'
 
-    @check_alive
     def ssh_reachable(self, tries=None, propagate_fail=True):
         """
         Check if the VM is reachable with ssh
@@ -556,6 +555,8 @@ class VMPlugin(plugins.Plugin):
         Returns:
             bool: True if the VM is reachable.
         """
+        if not self.alive():
+            return False
 
         try:
             ssh.get_ssh_client(


### PR DESCRIPTION
check_alive decorator raise RuntimeError if the vm is not running.
The API of ssh_reachable defines that "False" should be returned if the
vm is not ssh reachable (which is the case when the vm is not running).

Signed-off-by: gbenhaim <galbh2@gmail.com>