### PR TITLE
DO NOT MERGE: Investigate log collection failure on FC

### DIFF
--- a/tests/functional/collect.bats
+++ b/tests/functional/collect.bats
@@ -37,6 +37,8 @@ REPO_NAME="local_tests_repo"
     pushd "$FIXTURES"
     outdir="$FIXTURES/output"
     rm -rf "$outdir"
+    "$LAGOCLI" status
+    "$LAGOCLI" shell vm01 "hostname"
     helpers.run_ok "$LAGOCLI" --loglevel=debug collect --output "$outdir"
 }
 


### PR DESCRIPTION
On FC* log collection functional test fails because of a lock on the VM disk.
This happens because lago fallback to use Libguestfs for collecting
the logs from the vms (and then qemu and Libguestfs tries to access the
VM's disk). During this test, the VM should be available via SSH.

Signed-off-by: gbenhaim <galbh2@gmail.com>