### PR TITLE
Ask the provider if the vm is running

### DIFF
--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -153,6 +153,14 @@ class VMProviderPlugin(plugins.Plugin):
         pass
 
     @abstractmethod
+    def running(self, *args, **kwargs):
+        """
+        Returns:
+            (bool): True if the VM is running
+        """
+        pass
+
+    @abstractmethod
     def create_snapshot(self, name, *args, **kwargs):
         """
         Take any actions needed to create a snapshot
@@ -337,6 +345,12 @@ class VMPlugin(plugins.Plugin):
         """
         return self.provider.state(*args, **kwargs)
 
+    def running(self, *args, **kwargs):
+        """
+        Thin method that just uses the provider
+        """
+        return self.provider.running(*args, **kwargs)
+
     def create_snapshot(self, name, *args, **kwargs):
         """
         Thin method that just uses the provider
@@ -519,9 +533,6 @@ class VMPlugin(plugins.Plugin):
             username=self._spec.get('ssh-user'),
             password=self._spec.get('ssh-password'),
         )
-
-    def running(self):
-        return self.state() == 'running'
 
     def ssh_reachable(self, tries=None, propagate_fail=True):
         """

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -67,6 +67,14 @@ class LagoVMNotRunningError(utils.LagoUserException):
         super().__init__('VM {} is not running'.format(vm_name))
 
 
+class LagoVMDoesNotExistError(utils.LagoException):
+    pass
+
+
+class LagoFailedToGetVMStateError(utils.LagoException):
+    pass
+
+
 def check_running(func):
     @functools.wraps(func)
     def wrapper(self, *args, **kwargs):

--- a/lago/providers/libvirt/utils.py
+++ b/lago/providers/libvirt/utils.py
@@ -34,12 +34,17 @@ LOGGER = logging.getLogger(__name__)
 DOMAIN_STATES = {
     libvirt.VIR_DOMAIN_NOSTATE: 'no state',
     libvirt.VIR_DOMAIN_RUNNING: 'running',
-    libvirt.VIR_DOMAIN_BLOCKED: 'blocked',
+    libvirt.VIR_DOMAIN_BLOCKED: 'blocked',  # the domain is blocked on resource
     libvirt.VIR_DOMAIN_PAUSED: 'paused',
-    libvirt.VIR_DOMAIN_SHUTDOWN: 'beign shut down',
+    libvirt.VIR_DOMAIN_SHUTDOWN: 'begin shut down',
     libvirt.VIR_DOMAIN_SHUTOFF: 'shut off',
     libvirt.VIR_DOMAIN_CRASHED: 'crashed',
-    libvirt.VIR_DOMAIN_PMSUSPENDED: 'suspended',
+    libvirt.VIR_DOMAIN_PMSUSPENDED:
+        'suspended',  # the domain is suspended by guest power management
+}
+
+DOMAIN_RUNNING_STATES = {
+    libvirt.VIR_DOMAIN_RUNNING,
 }
 
 #: Singleton with the cached opened libvirt connections

--- a/lago/vm.py
+++ b/lago/vm.py
@@ -19,6 +19,7 @@
 #
 
 from lago.plugins import vm
+from lago import ssh
 
 
 class DefaultVM(vm.VMPlugin):
@@ -40,6 +41,21 @@ class SSHVMProvider(vm.VMProviderPlugin):
 
     def state(self, *args, **kwargs):
         return 'running'
+
+    def running(self, *args, **kwargs):
+        try:
+            ssh.get_ssh_client(
+                ip_addr=self.ip(),
+                host_name=self.name(),
+                propagate_fail=False,
+                ssh_key=self.virt_env.prefix.paths.ssh_id_rsa(),
+                username=self._spec.get('ssh-user'),
+                password=self._spec.get('ssh-password'),
+            )
+        except ssh.LagoSSHTimeoutException:
+            return False
+
+        return True
 
     def create_snapshot(self, name, *args, **kwargs):
         pass


### PR DESCRIPTION
#### Ask the provider if the VM is running

We ask the provider for the state of the VM, so it makes
sense to also ask the provider if the VM is running.

#### Improve VM state query
- Don't list all the VMs, just lookup the VM that is associated
  with the provider.

- Handle edge cases where an unknown state was returned from Libvirt,
  or when the VM doesn't exist.

closes https://github.com/lago-project/lago/issues/492
