### PR TITLE
Print Lago* exceptions' stack trace to lago.log

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -969,7 +969,7 @@ def main():
         cli_plugins[args.verb].do_run(args)
     except utils.LagoException as e:
         LOGGER.info(e.message)
-        LOGGER.debug(e)
+        LOGGER.debug(e, exc_info=True)
         sys.exit(2)
     except Exception:
         LOGGER.exception('Error occured, aborting')


### PR DESCRIPTION
It will make debugging easier.

Signed-off-by: gbenhaim <galbh2@gmail.com>