### PR TITLE
Remove debian8 image from functional tests

### DIFF
--- a/tests/functional-sdk/conftest.py
+++ b/tests/functional-sdk/conftest.py
@@ -12,11 +12,12 @@ _local_config = {
     },
     'check_merged':
         {
-            'images':
-                [
-                    'el7.4-base-1', 'el6-base', 'fc26-base', 'fc27-base',
-                    'ubuntu16.04-base', 'debian8-base'
-                ]
+            'images': [
+                'el7.4-base-1',
+                'el6-base',
+                'fc26-base',
+                'fc27-base',
+            ]
         }  # noqa: E123
 }
 


### PR DESCRIPTION
During the functional tests, the VM with this image boots
without a network. Due to a bug in libguestfs, we can't
collect logs from a VM without a network connection, so debugging should
be done manually.

Until we sort this out, remove this image from the functional tests in
order to not block other PRs.

Signed-off-by: gbenhaim <galbh2@gmail.com>