### PR TITLE
Improve error reporting

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -968,7 +968,7 @@ def main():
     try:
         cli_plugins[args.verb].do_run(args)
     except utils.LagoException as e:
-        LOGGER.info(e.message)
+        LOGGER.error(e.message)
         LOGGER.debug(e, exc_info=True)
         sys.exit(2)
     except Exception:

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -40,7 +40,7 @@ import xmltodict
 import paths
 import subnet_lease
 import utils
-from utils import LagoInitException
+from utils import LagoInitException, LagoException
 import virt
 import log_utils
 import build
@@ -1653,7 +1653,7 @@ class Prefix(object):
                 if ret != 0:
                     LOGGER.debug('STDOUT:\n%s' % out)
                     LOGGER.error('STDERR\n%s' % err)
-                    raise RuntimeError(
+                    raise LagoDeployError(
                         '%s failed with status %d on %s' % (
                             script,
                             ret,
@@ -1668,3 +1668,7 @@ class Prefix(object):
             self._deploy_host,
             self.virt_env.get_vms().values()
         )
+
+
+class LagoDeployError(LagoException):
+    pass

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -57,7 +57,11 @@ def _ret_via_queue(func, queue):
     try:
         queue.put({'return': func()})
     except Exception:
-        LOGGER.exception('Error while running thread')
+        LOGGER.debug(
+            'Error while running thread %s',
+            threading.current_thread().name,
+            exc_info=True
+        )
         queue.put({'exception': sys.exc_info()})
 
 


### PR DESCRIPTION
#### Print thread's exception info to the log

This change will improve the way we show errors to the user.
Most of the times, there is no need to expose the low level details of
an exception to the user. If needed, the information can be printed
explicitly.

#### Adding LagoDeployError

Use a custom exception if the invocation of the deploy scripts fails.
This change will hide the traceback from the user, while keeping
the stderr of the script.

#### Print exception message with logger.error

Error messages should be printed with the ERROR log level.