### PR TITLE
Fix build errors

### DIFF
--- a/lago/plugins/__init__.py
+++ b/lago/plugins/__init__.py
@@ -22,6 +22,7 @@
 """
 from stevedore import ExtensionManager
 import logging
+import warnings
 
 LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +33,12 @@ PLUGIN_ENTRY_POINTS = {
     'vm': 'lago.plugins.vm',
     'vm-service': 'lago.plugins.vm_service',
     'vm-provider': 'lago.plugins.vm_provider',
+}
+
+# Warnings that are emitted by stevedore package and we wnat to ignore.
+STEVEDORE_WARN_MSG = {
+    'Parameters to load are deprecated.  '
+    'Call .resolve and .require separately.',
 }
 
 
@@ -51,6 +58,17 @@ class Plugin(object):
 
 
 def load_plugins(namespace, instantiate=True):
+    with warnings.catch_warnings(record=True) as wlist:
+        plugins = _load_plugins(namespace, instantiate)
+        for warn in wlist:
+            msg = str(warn.message)
+            if msg not in STEVEDORE_WARN_MSG:
+                LOGGER.warning(msg)
+
+    return plugins
+
+
+def _load_plugins(namespace, instantiate=True):
     """
     Loads all the plugins for the given namespace
 

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -168,6 +168,8 @@ class Prefix(object):
                 'ssh-keygen',
                 '-t',
                 'rsa',
+                '-m',
+                'PEM',
                 '-N',
                 '',
                 '-f',

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 dulwich
-flake8
+flake8==3.5.0
 mock
 futures
 xmlunittest

--- a/tests/functional-sdk/conftest.py
+++ b/tests/functional-sdk/conftest.py
@@ -8,15 +8,15 @@ from lago_fixtures import (  # noqa: F401
 
 _local_config = {
     'check_patch': {
-        'images': ['el7.4-base']
+        'images': ['el7.5-base']
     },
     'check_merged':
         {
             'images': [
-                'el7.4-base-1',
+                'el7.5-base',
                 'el6-base',
-                'fc26-base',
-                'fc27-base',
+                'fc28-base',
+                'fc29-base',
             ]
         }  # noqa: E123
 }

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ whitelist_externals = /bin/bash
 
 [testenv:docs]
 passenv=PIP_CACHE_DIR HOME
+setenv =
+    LC_ALL = C
 skip_install=True
 changedir = docs
 commands = make clean


### PR DESCRIPTION
#### Use a fixed version of Falke8

This change will eliminate CI failures due to a change
in Flake8 version.

Flake8 version update should be manageable.

#### Set locale when building docs

Without setting the locale the build is failing with:

```
locale.setlocale(locale.LC_ALL, '')
locale.Error: unsupported locale setting
```

####  Ignore deprecation error caused by stevedore

setuptools (which is used by stevedore) 11.3 deprecated the required flag
to load() in favor of two new methods.

A fix was introduced in stevedore 1.2.0.

Since we are using and older version of stevedore (0.14) from epel,
lago outputs the deprecation warning, which isn't helpful for our users.

A long term solution will be to use a newer version of stevedore, but
currently it only available in Openstack repos.

#### Use PEM key format for ssh

OpenSSH-7.8 introudced a new key format which isn't supported by
paramiko [1]. Use PEM key format instead.

We have not seen this error in CI since the fallback is to use password
authentication.

#### Update the images we use in the functional tests

####  tests: Use retries when running systemd-analyze

"test_systemd_analyze" sporadically fails on
"Bootup is not yet finished. Please try again later".

Use retries in order to mitigate this issue.

Signed-off-by: gbenhaim <galbh2@gmail.com>