### PR TITLE
Change file locking method to flock

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -50,7 +50,6 @@ BuildArch: noarch
 BuildRequires: python2-devel
 BuildRequires: python-stevedore
 BuildRequires: python-setuptools
-BuildRequires: python-lockfile
 BuildRequires: python-yaml
 BuildRequires: pyxdg
 BuildRequires: python-xmltodict
@@ -90,7 +89,6 @@ Requires: libvirt >= 1.2.8
 Requires: libvirt-python
 Requires: python-libguestfs >= 1.30
 Requires: python-lxml
-Requires: python-lockfile
 Requires: python-pbr
 Requires: python-xmltodict
 Requires: python-scp

--- a/lago/templates.py
+++ b/lago/templates.py
@@ -19,7 +19,6 @@ definitions:
 
 """
 import errno
-import functools
 import json
 import logging
 import os
@@ -27,8 +26,6 @@ import posixpath
 import shutil
 import urllib
 import sys
-
-import lockfile
 
 import utils
 from . import log_utils
@@ -513,19 +510,6 @@ class TemplateVersion:
         self._source.download_image(self._handle, destination)
 
 
-def _locked(func):
-    """
-    Decorator that ensures that the decorated function has the lock of the
-    repo while running, meant to decorate only bound functions for classes that
-    have `lock_path` method.
-    """
-
-    @functools.wraps(func)
-    def wrapper(self, *args, **kwargs):
-        with lockfile.LockFile(self.lock_path()):
-            return func(self, *args, **kwargs)
-
-
 class TemplateStore:
     """
     Local cache to store templates
@@ -635,7 +619,7 @@ class TemplateStore:
         dest = self._prefixed(temp_ver.name)
         temp_dest = '%s.tmp' % dest
 
-        with lockfile.LockFile(dest):
+        with utils.LockFile(dest + '.lock'):
             # Image was downloaded while we were waiting
             if os.path.exists(dest):
                 return

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 configparser
 enum34
 libvirt-python
-lockfile
 lxml
 paramiko
 pbr

--- a/tests/unit/lago/test_lock.py
+++ b/tests/unit/lago/test_lock.py
@@ -1,0 +1,74 @@
+import signal
+from multiprocessing import Process, Event
+from os import WNOHANG, kill, waitpid
+from time import sleep
+
+import pytest
+
+from lago.utils import LockFile, TimerException
+
+
+def lock_path(run_path, duration, event=None):
+    with LockFile(run_path):
+        if event:
+            event.set()
+        sleep(duration)
+
+
+class ProcessWrapper(object):
+    def __init__(self, daemon=True, **kwargs):
+        self._p = Process(**kwargs)
+        self._p.daemon = daemon
+
+    def __getattr__(self, name):
+        return getattr(self._p, name)
+
+    def kill(self, sig=None):
+        sig = signal.SIGKILL if sig is None else sig
+        kill(self.pid, sig)
+
+    def waitpid(self):
+        return waitpid(self.pid, WNOHANG)
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, *args):
+        self.kill()
+
+
+@pytest.fixture
+def lockfile(tmpdir):
+    return str(tmpdir.join('test-lock'))
+
+
+@pytest.fixture
+def event():
+    return Event()
+
+
+@pytest.fixture
+def p_wrapper(lockfile, event):
+    duration = 60
+    event.clear()
+
+    return ProcessWrapper(target=lock_path, args=(lockfile, duration, event))
+
+
+def test_should_fail_to_lock_when_already_locked(lockfile, p_wrapper, event):
+    with p_wrapper:
+        assert event.wait(30), 'Timeout while waiting for child process'
+        with pytest.raises(TimerException), LockFile(lockfile, timeout=1):
+            pass
+
+
+def test_should_succeed_to_lock_a_stale_lock(lockfile, p_wrapper, event):
+    p_wrapper.start()
+    assert event.wait(30), 'Timeout while waiting for child process'
+
+    p_wrapper.kill()
+    # If the process is still running waitpid returns (0, 0)
+    assert not any(p_wrapper.waitpid()), 'Failed to kill child process'
+
+    with LockFile(lockfile, timeout=1):
+        pass


### PR DESCRIPTION
The current locking method leaves stale lock when Lago
is being terminated using SIGKILL.
Using flock we can overcome this issue.

Also:

1. Make FileLock context manager more generic.
2. Add a test.
3. Adjust templates.py - we don't use the "_lock" decorator.

Signed-off-by: gbenhaim <galbh2@gmail.com>