### PR TITLE
Fix comparison between "LogRecord" and "level"

### DIFF
--- a/lago/log_utils.py
+++ b/lago/log_utils.py
@@ -324,7 +324,7 @@ class TaskHandler(logging.StreamHandler):
 
         return (self.task_tree_depth < 0 or self.task_tree_depth >= cur_level)
 
-    def should_show_by_level(self, record_level, base_level=None):
+    def should_show_by_level(self, record, base_level=None):
         """
         Args:
             record_level (int): log level of the record to check
@@ -338,7 +338,7 @@ class TaskHandler(logging.StreamHandler):
         if base_level is None:
             base_level = self.dump_level
 
-        return record_level >= base_level
+        return record.levelno >= base_level
 
     def handle_new_task(self, task_name, record):
         """


### PR DESCRIPTION
Don't compare log level with `LogRecord` instance, use `levelno` attribute instead.

Can be tested using this snippet:

    >>> from logging import LogRecord, DEBUG, INFO
    >>> DEBUG, INFO
    (10, 20)
    >>> LogRecord(None, DEBUG, None, None, "msg", None, None) >= INFO
    True
    >>> LogRecord(None, DEBUG, None, None, "msg", None, None).levelno >= INFO
    False