### PR TITLE
Remove erroneous call to hexdigest method

### DIFF
--- a/docs/docs-requires.txt
+++ b/docs/docs-requires.txt
@@ -5,6 +5,6 @@ sphinx>1.0
 dulwich
 configparser
 pyxdg
-nbsphinx
+nbsphinx!=0.4.0,!=0.4.1
 pypandoc
 ipython

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -543,6 +543,7 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
             )
 
         if not qemu_kvm_path:
+            LOGGER.warning("emulator not found %r", ET.tostring(self.caps))
             raise utils.LagoException('kvm executable not found')
 
         return qemu_kvm_path

--- a/lago/templates.py
+++ b/lago/templates.py
@@ -651,7 +651,7 @@ class TemplateStore:
                 raise RuntimeError(
                     'Image %s does not match the expected hash %s' % (
                         temp_ver.name,
-                        sha1.hexdigest(),
+                        sha1,
                     )
                 )
 

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -5,7 +5,7 @@ mock
 futures
 xmlunittest
 yapf==0.20
-pytest
+pytest>=3.6.0
 pytest-cov
 pytest-timeout
 pytest-catchlog

--- a/tests/functional-sdk/conftest.py
+++ b/tests/functional-sdk/conftest.py
@@ -46,9 +46,9 @@ def pytest_generate_tests(metafunc):
 
 def pytest_runtest_setup(item):
     stage = pytest.config.getoption('--stage')
-    if item.get_marker('check_merged') and stage == 'check_patch':
+    if item.get_closest_marker('check_merged') and stage == 'check_patch':
         pytest.skip('runs only on check_merged stage')
-    elif item.get_marker('check_patch') and stage == 'check_merged':
+    elif item.get_closest_marker('check_patch') and stage == 'check_merged':
         pytest.skip('runs only on check_patch stage')
 
 


### PR DESCRIPTION
* `sha1` is [already a digest](https://github.com/pilou-/lago/blob/cb6a8d0295d89a9cea848fcd52ac25e80aad3b36/lago/utils.py#L745). Error was:

      AttributeError: 'str' object has no attribute 'hexdigest'

* Fix the CI:
  * `nbsphinx` version: `nonlocal` statement is [used since 0.4.0](https://github.com/spatialaudio/nbsphinx/blob/11a6e4da3eadc1a4dda189e4fcc1685853665f08/src/nbsphinx.py#L1088) and [breaks Python 2 compatibility](https://jenkins.ovirt.org/blue/organizations/jenkins/lago_master_github_check-patch-el7-x86_64/detail/lago_master_github_check-patch-el7-x86_64/972/pipeline#log-1040): exclude incompatible `nbsphinx` versions.
  * use `get_closest_mark` instead of `get_marker`: `get_closest_mark` is [available since pytest 3.6.0](https://github.com/pytest-dev/pytest/blame/3.6.0/CHANGELOG.rst#L17-L26) and `get_marker` has been [`removed form pytest 4.1.0`](https://github.com/pytest-dev/pytest/blame/4.1.0/CHANGELOG.rst#L89-L91).