### PR TITLE
tests: Fix config tests for non-standard config

### DIFF
--- a/tests/unit/lago/test_config.py
+++ b/tests/unit/lago/test_config.py
@@ -109,9 +109,10 @@ def test_default_dict_empty():
     ]
 )
 def test_default_dict_loading(defaults):
-    config_load = config.ConfigLoad(defaults=defaults)
-    for key, value in defaults.iteritems():
-        assert config_load.get_section(key) == value
+    with patch('lago.config._get_configs_path', return_value=[]):
+        config_load = config.ConfigLoad(defaults=defaults)
+        for key, value in defaults.iteritems():
+            assert config_load.get_section(key) == value
 
 
 @patch('lago.config.open', new_callable=mock_open)
@@ -277,9 +278,10 @@ def test_key_only_in_file_exists(mocked_configs_path, mocked_open):
     ]
 )
 def test_get_ini(defaults):
-    config_load = config.ConfigLoad(defaults=defaults)
-    expected = _ini_from_dict(defaults)
-    assert config_load.get_ini() == expected
+    with patch('lago.config._get_configs_path', return_value=[]):
+        config_load = config.ConfigLoad(defaults=defaults)
+        expected = _ini_from_dict(defaults)
+        assert config_load.get_ini() == expected
 
 
 def test_get_ini_include_unset():


### PR DESCRIPTION
When a developer has a '$HOME/.config/lago/lago.conf' config file
defined, 1:1 configuration comparisons fail - 'ConfigLoad' will add
configuration elements found in the file. This patch uses 'mock.patch'
to trick tests into thinking, that there are no user-defined
configuration files.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>