### PR TITLE
Extract paths reimplementation

### DIFF
--- a/lago.spec.in
+++ b/lago.spec.in
@@ -118,6 +118,7 @@ Requires: qemu-kvm >= 2.1.2
 %endif
 Requires: git
 Requires: sudo
+Requires: tar
 %{?python_provide:%python_provide python2-lago}
 
 %description -n python-%{name}

--- a/lago/plugins/vm.py
+++ b/lago/plugins/vm.py
@@ -29,10 +29,13 @@ for example, using a remote libvirt instance or similar.
 """
 from copy import deepcopy
 import contextlib
+import errno
 import functools
 from future.builtins import super
 import logging
 import os
+import shutil
+import tempfile
 import warnings
 from abc import (ABCMeta, abstractmethod)
 from scp import SCPClient, SCPException
@@ -246,12 +249,98 @@ class VMProviderPlugin(plugins.Plugin):
             :exc:`~lago.plugins.vm.ExtractPathError`: on all other failures.
         """
         try:
-            self._extract_paths_scp(paths=paths, ignore_nopath=ignore_nopath)
+            if self._has_tar_and_gzip():
+                self._extract_paths_tar_gz(paths, ignore_nopath)
+            else:
+                self._extract_paths_scp(paths, ignore_nopath)
         except (ssh.LagoSSHTimeoutException, LagoVMNotRunningError):
             raise ExtractPathError(
                 'Unable to extract paths from {0}: unreachable with SSH'.
                 format(self.vm.name())
             )
+
+    @check_running
+    def _has_tar_and_gzip(self):
+        with self.vm._ssh() as client:
+            _, stdout, _ = client.exec_command("ls /usr/bin/tar")
+            if stdout.read().strip() != "/usr/bin/tar":
+                return False
+            _, stdout, _ = client.exec_command("ls /usr/bin/gzip")
+            if stdout.read().strip() != "/usr/bin/gzip":
+                return False
+        return True
+
+    @staticmethod
+    def _prepare_tar_gz_command(remote_paths, compression_level):
+        cmd = "tar --dereference -c {} | gzip -f -{}"
+        remote_paths_arg = " ".join(remote_paths)
+        return cmd.format(remote_paths_arg, compression_level)
+
+    def _pipe_ssh_cmd_output_to_file(self, cmd, out_file):
+        with self.vm._ssh() as client:
+            _, stdout, _ = client.exec_command(cmd)
+            out_file.write(stdout.read())
+            out_file.flush()
+            os.fsync(out_file.fileno())
+
+    @contextlib.contextmanager
+    def _tar_gz_archive_from(self, remote_paths, compression_level=5):
+        with tempfile.NamedTemporaryFile() as archive_file:
+            tar_gz_cmd = self._prepare_tar_gz_command(
+                remote_paths, compression_level
+            )
+            self._pipe_ssh_cmd_output_to_file(tar_gz_cmd, archive_file)
+            LOGGER.debug(
+                "Created %s archive with collected paths", archive_file.name
+            )
+            yield archive_file
+
+    @contextlib.contextmanager
+    def _remote_paths_extracted_to_temp_dir(self, remote_paths):
+        with self._tar_gz_archive_from(remote_paths) as archive_file:
+            with utils.TemporaryDirectory() as tmpdir_path:
+                LOGGER.debug(
+                    "Extracting archive %s to temporary directory: %s",
+                    archive_file.name, tmpdir_path
+                )
+                args = ["tar", "-xf", archive_file.name, "-C", tmpdir_path]
+                cmd_status = utils.run_command(args)
+                if cmd_status.code != 0:
+                    LOGGER.error("'tar' command failed: %s", cmd_status.err)
+                yield tmpdir_path
+
+    @check_running
+    def _extract_paths_tar_gz(self, paths, ignore_nopath):
+        remote_paths = tuple(p[0] for p in paths)
+
+        with self._remote_paths_extracted_to_temp_dir(
+            remote_paths
+        ) as tmpdir_path:
+            for remote_path, desired_local_path in paths:
+                LOGGER.debug(
+                    'Moving %s to %s',
+                    remote_path,
+                    desired_local_path,
+                )
+                try:
+                    # we need to strip first slash from absolute
+                    # 'remote_path' to make 'os.path.join' work
+                    current_local_path = os.path.join(
+                        tmpdir_path, remote_path[1:]
+                    )
+                    shutil.move(current_local_path, desired_local_path)
+                except IOError as e:
+                    if e.errno == errno.ENOENT:
+                        if ignore_nopath:
+                            msg = (
+                                '%s: ignoring since ignore_nopath '
+                                'was set to True'
+                            )
+                            LOGGER.debug(msg, remote_path)
+                        else:
+                            raise ExtractPathNoPathError(remote_path)
+                    else:
+                        raise
 
     @check_running
     def _extract_paths_scp(self, paths, ignore_nopath):

--- a/lago/utils.py
+++ b/lago/utils.py
@@ -30,6 +30,7 @@ import signal
 import subprocess
 import sys
 import threading
+import tempfile
 import textwrap
 import time
 import yaml
@@ -447,6 +448,28 @@ class LockFile(object):
         LOGGER.debug('Trying to release lock for {}'.format(self.path))
         self.lock.release()
         LOGGER.debug('Lock for {} was released'.format(self.path))
+
+
+class TemporaryDirectory(object):
+    """
+    Context manager that creates a temporary directory and provides
+    its path as a property.
+
+    Args:
+        ignore_errors(bool): ignore errors when trying to remove directory
+    Raises:
+        OSError: anything that 'shutil.rmtree' might raise
+    """
+
+    def __init__(self, ignore_errors=True):
+        self._path = tempfile.mkdtemp()
+        self._ignore_errors = ignore_errors
+
+    def __enter__(self):
+        return self._path
+
+    def __exit__(self, *_):
+        shutil.rmtree(self._path, self._ignore_errors)
 
 
 def read_nonblocking(file_descriptor):

--- a/tests/unit/lago/test_utils.py
+++ b/tests/unit/lago/test_utils.py
@@ -1,6 +1,10 @@
 import json
+import os
 import yaml
+
 from StringIO import StringIO
+
+import pytest
 
 from lago import utils
 
@@ -107,3 +111,33 @@ class TestLoadVirtStream(object):
         expected = {'one': 1}
         loaded_conf = utils.load_virt_stream(virt_fd=bad_json)
         assert deep_compare(expected, loaded_conf)
+
+
+def test_should_give_a_temporary_directory_in():
+    remembered_dir_path = None
+    remembered_file_path = None
+
+    with utils.TemporaryDirectory() as tmpdir_path:
+        remembered_dir_path = tmpdir_path
+
+        assert os.path.isdir(tmpdir_path)
+
+        some_file_path = os.path.join(tmpdir_path, "smth")
+        remembered_file_path = some_file_path
+
+        with open(some_file_path, "w") as some_file:
+            some_file.write("stuff")
+        assert os.path.isfile(some_file_path)
+
+    assert not os.path.exists(remembered_dir_path)
+    assert not os.path.exists(remembered_file_path)
+
+
+def test_temporary_directory_should_respect_ignoring_errors_in():
+    with utils.TemporaryDirectory(ignore_errors=True) as tmpdir_path:
+        os.rmdir(tmpdir_path)
+        assert not os.path.exists(tmpdir_path)
+
+    with pytest.raises(OSError):
+        with utils.TemporaryDirectory(ignore_errors=False) as tmpdir_path:
+            os.rmdir(tmpdir_path)


### PR DESCRIPTION
Using 'scp' to copy a lot of data in a file-by-file manner is very
inefficient. This patch changes the way path extraction works:

- it creates a tar.gz archive containing all desired files on remote side
- uses ssh to redirect the output of tar|gzip pipe directly to local side (there are no files created on the remote side)
- extracts .tar.gz file to a temporary directory on the local side
- moves all the extracted files from temporary directory to target destination, at the same time renaming them to desired names

This algorithm offers drastic speed-ups when dealing with collection of a large dataset i.e. for oVirt System Tests, it reduces the time needed to collect artifacts from ~20 secs to ~2 secs. This in turn, trims down the running time of each OST suite by a couple of minutes.