### PR TITLE
Set file permissions on lock files

### DIFF
--- a/lago/utils.py
+++ b/lago/utils.py
@@ -395,6 +395,7 @@ class Flock(object):
             IOError: if the call to flock fails
         """
         self._fd = open(self._path, mode='w+')
+        os.chmod(self._path, 0o660)
         fcntl.flock(self._fd, self._op)
 
     def release(self):


### PR DESCRIPTION
Explicitly set the permissions of lock files, thus even if umask other
then '0002' is configured, different users in the lago group can try to
acquire the lock.

Signed-off-by: gbenhaim <galbh2@gmail.com>