### PR TITLE
do not merge: Use fixed scp version in the func test

### DIFF
--- a/tox-sdk.ini
+++ b/tox-sdk.ini
@@ -19,6 +19,7 @@ deps = http://download.libguestfs.org/python/guestfs-1.36.4.tar.gz
        pytest-timeout
        pytest-catchlog
        Jinja2
+       scp==0.13.0
 commands =  pytest -vvv \
                 -x \
                 {posargs} \


### PR DESCRIPTION
I suspect that scp==0.13.1 introduce a bug that cause "test_collect_exists"
to fail with the following error:

self = <scp.SCPClient object at 0x7fa27813c690>, cmd = ('',)

    def _recv_popd(self, *cmd):
>       assert self._depth > 0
E       AssertionError

Signed-off-by: gbenhaim <galbh2@gmail.com>