### PR TITLE
Throw error if yum install failed in deploy.sh

### DIFF
--- a/container/el7-systemd-lago/deploy.sh
+++ b/container/el7-systemd-lago/deploy.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -ex
+#!/bin/bash
+set -ex
 
 shopt -s failglob
 readonly rpm_dir="${1:?}"
@@ -7,7 +8,7 @@ readonly rpm_dir="${1:?}"
     cd "$rpm_dir"
     rpms=(epel-release centos-release-qemu-ev)
     rpms+=($(ls *.rpm))
-    yum install -y "${rpms[@]}"
+    yum install -y --setopt=skip_missing_names_on_install=False "${rpms[@]}"
     for pkg in "${rpms[@]}"; do
         rpm -V "${pkg%.rpm}"
     done


### PR DESCRIPTION
Currently yum's return code for installing more than one package
at a time with the "-y" flag is successful if at least one
installation was successful - thus not throwing an error if any
package was skipped.

Adding the --setopt=skip_missing_names_on_install=False flag
solves this issue.

Source https://bugzilla.redhat.com/show_bug.cgi?id=1274211