### PR TITLE
out-format: Always print yaml in block style

### DIFF
--- a/lago/plugins/output.py
+++ b/lago/plugins/output.py
@@ -104,7 +104,7 @@ class JSONOutFormatPlugin(OutFormatPlugin):
 
 class YAMLOutFormatPlugin(OutFormatPlugin):
     def format(self, info_dict):
-        return yaml.dump(info_dict)
+        return yaml.dump(info_dict, default_flow_style=False)
 
 
 class FlatOutFormatPlugin(OutFormatPlugin):

--- a/tests/functional/fixtures/status/prefix_skel/expected.yaml
+++ b/tests/functional/fixtures/status/prefix_skel/expected.yaml
@@ -1,16 +1,24 @@
 Prefix:
   Base directory: @@PREFIX@@
   Networks:
-    !!python/unicode 'n0': {gateway: !!python/unicode '192.168.201.1', management: true,
-      status: down}
-    !!python/unicode 'n1': {gateway: !!python/unicode '192.168.202.1', management: false,
-      status: down}
+    !!python/unicode 'n0':
+      gateway: !!python/unicode '192.168.201.1'
+      management: true
+      status: down
+    !!python/unicode 'n1':
+      gateway: !!python/unicode '192.168.202.1'
+      management: false
+      status: down
   UUID: fe689d3c39d011e5b22b54ee755a00ca
   VMs:
     vm0:
       NICs:
-        eth0: {ip: !!python/unicode '192.168.201.2', network: !!python/unicode 'n0'}
-        eth1: {ip: !!python/unicode '192.168.202.2', network: !!python/unicode 'n1'}
+        eth0:
+          ip: !!python/unicode '192.168.201.2'
+          network: !!python/unicode 'n0'
+        eth1:
+          ip: !!python/unicode '192.168.202.2'
+          network: !!python/unicode 'n1'
       distro: !!python/unicode 'cirros'
       metadata: {}
       root password: !!python/unicode '123456'
@@ -18,8 +26,12 @@ Prefix:
       status: down
     vm1:
       NICs:
-        eth0: {ip: !!python/unicode '192.168.201.3', network: !!python/unicode 'n0'}
-        eth1: {ip: !!python/unicode '192.168.202.3', network: !!python/unicode 'n1'}
+        eth0:
+          ip: !!python/unicode '192.168.201.3'
+          network: !!python/unicode 'n0'
+        eth1:
+          ip: !!python/unicode '192.168.202.3'
+          network: !!python/unicode 'n1'
       distro: !!python/unicode 'cirros'
       metadata: {}
       root password: !!python/unicode 'cubswin:)'


### PR DESCRIPTION
- Block style is more readable.
- Setting the style explicitly in Lago will make the output
  deterministic (not dependent on python yaml defaults).

Signed-off-by: gbenhaim <galbh2@gmail.com>