### PR TITLE
Revert "Remove debian based images from functional tests"

### DIFF
--- a/tests/functional-sdk/conftest.py
+++ b/tests/functional-sdk/conftest.py
@@ -12,12 +12,11 @@ _local_config = {
     },
     'check_merged':
         {
-            'images': [
-                'el7.6-base-2',
-                'el6-base',
-                'fc28-base',
-                'fc29-base',
-            ]
+            'images':
+                [
+                    'el7.6-base-2', 'el6-base', 'fc28-base', 'fc29-base',
+                    'ubuntu16.04-base', 'debian8-base'
+                ]
         }  # noqa: E123
 }
 


### PR DESCRIPTION
This reverts commit 9affcfe365f5ad2d1d3aa96f019474861076777a.

We changed the ssh key type that we use for connecting to the VMs,
so we should be able to test the Debian based images now.
(c58c3c6b89e82220bb1599867d167e698b0d6478).

Signed-off-by: gbenhaim <galbh2@gmail.com>