### PR TITLE
Fix failure in running tox -e docs

### DIFF
--- a/automation/check-patch.packages
+++ b/automation/check-patch.packages
@@ -2,6 +2,7 @@ ansible
 bats
 dnf
 dnf-command(builddep)
+gcc
 git
 grubby
 libffi-devel

--- a/lago/providers/libvirt/cpu.py
+++ b/lago/providers/libvirt/cpu.py
@@ -19,6 +19,7 @@
 #
 
 import logging
+import libvirt
 
 from lxml import etree as ET
 
@@ -392,6 +393,18 @@ class LibvirtCPU(object):
 
     @classmethod
     def get_cpus_by_arch(cls, arch):
+        conn = libvirt.open('qemu:///system')
+        if conn is None:
+            raise LagoException('Failed to open connection to qemu:///system')
+        models = conn.getCPUModelNames('x86_64')
+        conn.close()
+        if models:
+            return models[0]
+        else:
+            raise LagoException('No such arch: {0}'.format(arch))
+
+    @classmethod
+    def get_cpus_by_arch1(cls, arch):
         """
         Get all CPUs info by arch
 

--- a/lago/providers/libvirt/cpu.py
+++ b/lago/providers/libvirt/cpu.py
@@ -19,8 +19,7 @@
 #
 
 import logging
-import libvirt
-
+import os
 from lxml import etree as ET
 
 import lago.providers.libvirt.utils as utils
@@ -393,18 +392,6 @@ class LibvirtCPU(object):
 
     @classmethod
     def get_cpus_by_arch(cls, arch):
-        conn = libvirt.open('qemu:///system')
-        if conn is None:
-            raise LagoException('Failed to open connection to qemu:///system')
-        models = conn.getCPUModelNames('x86_64')
-        conn.close()
-        if models:
-            return models[0]
-        else:
-            raise LagoException('No such arch: {0}'.format(arch))
-
-    @classmethod
-    def get_cpus_by_arch1(cls, arch):
         """
         Get all CPUs info by arch
 
@@ -418,9 +405,40 @@ class LibvirtCPU(object):
             :exc:`~LagoException`: If no such ARCH is found
         """
 
-        with open('/usr/share/libvirt/cpu_map.xml', 'r') as cpu_map:
-            cpu_xml = ET.parse(cpu_map)
+        cpu_map_xml = "/usr/share/libvirt/cpu_map.xml"
+        cpu_map_dir = "/usr/share/libvirt/cpu_map/"
+        cpu_map_index_xml = cpu_map_dir + "index.xml"
+        if not os.path.exists(cpu_map_xml):
+            cpu_xml = ET.ElementTree(
+                ET.fromstring(create_xml_map(cpu_map_index_xml, cpu_map_dir))
+            )
+        else:
+            with open(cpu_map_xml, 'r') as cpu_map:
+                cpu_xml = ET.parse(cpu_map)
         try:
             return cpu_xml.xpath('/cpus/arch[@name="{0}"]'.format(arch))[0]
         except IndexError:
             raise LagoException('No such arch: {0}'.format(arch))
+
+
+def create_xml_map(cpu_map_index_xml, cpu_map_dir):
+    xml_list = []
+    if os.path.exists(cpu_map_index_xml):
+        with open(cpu_map_index_xml) as fp:
+            line = fp.readline()
+            while line:
+                if "include" in line:
+                    tree = ET.fromstring(line)
+                    for child in tree.getiterator():
+                        if child.tag == "include":
+                            filename = child.attrib["filename"]
+                            with open(
+                                cpu_map_dir + filename, 'r'
+                            ) as content_file:
+                                for content_line in content_file:
+                                    if "cpus" not in content_line:
+                                        xml_list.append(content_line)
+                else:
+                    xml_list.append(line)
+                line = fp.readline()
+    return ''.join(xml_list)

--- a/tests/unit/lago/providers/libvirt/fixtures/cpu_map/index.xml
+++ b/tests/unit/lago/providers/libvirt/fixtures/cpu_map/index.xml
@@ -1,0 +1,5 @@
+<cpus>
+    <arch name="x86">
+         <include filename="x86_Penryn.xml"/>
+    </arch>
+</cpus>

--- a/tests/unit/lago/providers/libvirt/fixtures/cpu_map/x86_Penryn.xml
+++ b/tests/unit/lago/providers/libvirt/fixtures/cpu_map/x86_Penryn.xml
@@ -1,0 +1,7 @@
+ <cpus>
+      <model name='Penryn'>
+          <signature family='6' model='23'/>
+          <vendor name='Intel'/>
+          <feature name='apic'/>
+      </model>
+ </cpus>

--- a/tests/unit/lago/providers/libvirt/test_cpu.py
+++ b/tests/unit/lago/providers/libvirt/test_cpu.py
@@ -23,7 +23,7 @@ from itertools import permutations
 import lxml.etree as ET
 import pytest
 from xmlunittest import XmlTestCase
-
+import os
 from lago.providers.libvirt import cpu
 from lago.utils import LagoInitException
 
@@ -247,3 +247,23 @@ class TestCPU(XmlTestCase):
         }
         with pytest.raises(LagoInitException):
             cpu.CPU(spec=spec, host_cpu=self.get_host_cpu())
+
+    def test_create_xml_string(self):
+        _xml = """
+        <cpus>
+            <arch name="x86">
+               <model name='Penryn'>
+                   <signature family='6' model='23'/>
+                   <vendor name='Intel'/>
+                   <feature name='apic'/>
+               </model>
+            </arch>
+        </cpus>
+        """
+        test_dir = os.path.dirname(__file__)
+        cpu_map_dir = test_dir + "/fixtures/cpu_map/"
+        cpu_map_index_xml = cpu_map_dir + "index.xml"
+        cpu_xml = ET.fromstring(
+            cpu.create_xml_map(cpu_map_index_xml, cpu_map_dir)
+        )
+        self.assertXmlEquivalentOutputs(ET.tostring(cpu_xml), _xml)


### PR DESCRIPTION
On fedora29 the tox is failing   docs: could not install deps

Signed-off-by: Galit <grosenth@redhat.com>