### PR TITLE
ci: Move libvirt and libguestfs deps to RPM level

### DIFF
--- a/automation/check-patch.packages.el7
+++ b/automation/check-patch.packages.el7
@@ -4,11 +4,13 @@ git
 libffi-devel
 libguestfs-devel
 libvirt-devel
+libvirt-python
 libxslt-devel
 openssl-devel
 pandoc
 python2-devel
 python-dulwich
+python-libguestfs
 python-pip
 yum
 yum-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 configparser
 enum34
-libvirt-python
 lxml
 paramiko
 pbr

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -9,6 +9,3 @@ pytest>=3.6.0
 pytest-cov
 pytest-timeout
 pytest-catchlog
-# guestfs is not available on PyPI, however it can be installed
-# with a direct link.
-http://download.libguestfs.org/python/guestfs-1.36.4.tar.gz

--- a/tox-sdk.ini
+++ b/tox-sdk.ini
@@ -12,13 +12,13 @@ setenv =
 
 passenv=TEST_RESULTS PIP_CACHE_DIR LIBVIRT_DEBUG LIBVIRT_LOG_OUTPUTS
 changedir=tests/functional-sdk
-deps = http://download.libguestfs.org/python/guestfs-1.36.4.tar.gz
-       six
-       pytest
-       pytest-cov
-       pytest-timeout
-       pytest-catchlog
-       Jinja2
+deps =
+    six
+    pytest
+    pytest-cov
+    pytest-timeout
+    pytest-catchlog
+    Jinja2
 commands =  pytest -vvv \
                 -x \
                 {posargs} \
@@ -27,4 +27,5 @@ commands =  pytest -vvv \
                 --cov-report html \
                 --cov-report term \
                 --cov-report xml
+sitepackages = true
 whitelist_externals = lago

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands = {toxinidir}/scripts/check_style.sh
                 tests/unit
 deps =
       -r{toxinidir}/test-requires.txt
-
+sitepackages = true
 whitelist_externals = /bin/bash
 
 [testenv:sdist]
@@ -24,6 +24,7 @@ deps =
     {toxinidir}/exported-artifacts/lago*.tar.gz
 commands = lago --version
 whitelist_externals = /bin/bash
+sitepackages = true
 
 [testenv:docs]
 passenv=PIP_CACHE_DIR HOME


### PR DESCRIPTION
Both libvirt and libguestfs python libraries are tightly coupled
with their C equivalents. We cannot use arbitrary versions of those
libs from PyPI - we need to stick to the ones provided by the distro.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>