### PR TITLE
Fixes in 'prefix' module

### DIFF
--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -872,6 +872,9 @@ class Prefix(object):
         if not parent:
             return
 
+        if not os.path.isabs(parent):
+            parent = os.path.join(os.path.dirname(disk_path), parent)
+
         if os.path.isfile(parent):
             if os.path.samefile(
                 os.path.realpath(parent),

--- a/lago/prefix.py
+++ b/lago/prefix.py
@@ -845,7 +845,8 @@ class Prefix(object):
         self.resolve_parent(base_path, template_store, template_repo)
 
         qemu_cmd = [
-            'qemu-img', 'create', '-f', 'qcow2', '-b', base_path, disk_path
+            'qemu-img', 'create', '-f', 'qcow2', '-F', 'qcow2', '-b',
+            base_path, disk_path
         ]
         disk_metadata = template_spec.get('metadata', {})
         return qemu_cmd, disk_metadata


### PR DESCRIPTION
This PR adds a fix for libvirt 6 that requires backing file formats to be specified explicitly and support for relative backing file paths to lago.