### PR TITLE
Add '--ssh-key' option to 'lago init'

### DIFF
--- a/lago/cmd.py
+++ b/lago/cmd.py
@@ -113,6 +113,14 @@ in_lago_prefix = in_prefix(
         'section of all the disks'
     ),
 )
+@lago.plugins.cli.cli_plugin_add_argument(
+    '--ssh-key',
+    action='store',
+    help=(
+        'If passed, will be used for ssh access to VMs and no keys will '
+        'be generated'
+    ),
+)
 def do_init(
     workdir,
     virt_config,
@@ -124,6 +132,7 @@ def do_init(
     set_current=False,
     skip_bootstrap=False,
     skip_build=False,
+    ssh_key=None,
     **kwargs
 ):
 
@@ -160,7 +169,7 @@ def do_init(
                 workdir.path,
                 prefix_name,
             )
-            prefix = workdir.initialize(prefix_name)
+            prefix = workdir.initialize(prefix_name, ssh_key)
         else:
             LOGGER.debug(
                 'Adding prefix %s to workdir %s',
@@ -195,6 +204,7 @@ def do_init(
                     store,
                     do_bootstrap=not skip_bootstrap,
                     do_build=not skip_build,
+                    ssh_key=ssh_key,
                 )
 
             if set_current:

--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -431,8 +431,10 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
         """
         if not self._has_guestfs:
             raise LagoException(
-                ('guestfs module not available, cannot '
-                 )('extract files with libguestfs')
+                (
+                    'guestfs module not available, cannot '
+                    'extract files with libguestfs'
+                )
             )
 
         LOGGER.debug(

--- a/lago/workdir.py
+++ b/lago/workdir.py
@@ -109,12 +109,13 @@ class Workdir(object):
         """
         return os.path.join(self.path, *args)
 
-    def initialize(self, prefix_name='default', *args, **kwargs):
+    def initialize(self, prefix_name='default', ssh_key=None, *args, **kwargs):
         """
         Initializes a workdir by adding a new prefix to the workdir.
 
         Args:
             prefix_name(str): Name of the new prefix to add
+            ssh_key(str): Optional path to existing ssh key to be used
             *args: args to pass along to the prefix constructor
             *kwargs: kwargs to pass along to the prefix constructor
 
@@ -135,7 +136,7 @@ class Workdir(object):
         self.prefixes[prefix_name] = self.prefix_class(
             self.join(prefix_name), *args, **kwargs
         )
-        self.prefixes[prefix_name].initialize()
+        self.prefixes[prefix_name].initialize(ssh_key)
         if self.current is None:
             self._set_current(prefix_name)
 

--- a/test-requires.txt
+++ b/test-requires.txt
@@ -5,6 +5,7 @@ mock
 futures
 xmlunittest
 yapf==0.20
+pyflakes>=2.1.0
 pytest>=3.6.0
 pytest-cov
 pytest-timeout

--- a/tests/unit/lago/test_workdir.py
+++ b/tests/unit/lago/test_workdir.py
@@ -125,7 +125,7 @@ class TestWorkdir(object):
         my_prefix_instance = my_workdir.initialize(prefix_name=prefix_name)
 
         my_prefix.assert_called_with(my_workdir.join(prefix_name))
-        my_prefix_instance.initialize.assert_called_with()
+        my_prefix_instance.initialize.assert_called_with(None)
         assert not mock_makedirs.method_calls
         mock_exists.assert_called_with(my_workdir.join())
         mock_set_current.assert_called_with(prefix_name)
@@ -166,7 +166,7 @@ class TestWorkdir(object):
         my_prefix_instance = my_workdir.initialize(prefix_name=prefix_name)
 
         my_prefix.assert_called_with(my_workdir.join(prefix_name))
-        my_prefix_instance.initialize.assert_called_with()
+        my_prefix_instance.initialize.assert_called_with(None)
         mock_makedirs.assert_called_with(my_workdir.join())
         mock_exists.assert_called_with(my_workdir.join())
         mock_set_current.assert_called_with(prefix_name)


### PR DESCRIPTION
This PR adds a '--ssh-key' option to 'lago init' command. This makes possible using ssh keys which are already injected into VM. On top of that, there are two small py38 fixes.