### PR TITLE
ansible: Update how we generate inventory

### DIFF
--- a/lago/lago_ansible.py
+++ b/lago/lago_ansible.py
@@ -74,18 +74,11 @@ class LagoAnsible(object):
                 value = self.get_key(key, vm_spec)
                 if value is None:
                     continue
-                if isinstance(value, list):
-                    for sub_value in value:
-                        inventory['{}={}'.format(key, sub_value)].append(entry)
-                else:
-                    inventory['{}={}'.format(key, value)].append(entry)
-
-            # Adding a special case for the group key.
-            # Most of the times the user wants that the host
-            # will be a part of the group "group", and not a part of
-            # "group=something"
-            for group in vm_spec.get('groups', []):
-                inventory[group].append(entry)
+                if not isinstance(value, list):
+                    value = [value]
+                for sub_value in value:
+                    inventory['{}'.format(sub_value.replace('-', '_')
+                                          )].append(entry)
 
         return inventory
 

--- a/tests/unit/lago/test_lago_ansible.py
+++ b/tests/unit/lago/test_lago_ansible.py
@@ -145,34 +145,34 @@ class TestLagoAnsible(object):
         'keys, expected', [
             (['/f'], {}), (
                 None, {
-                    'groups=masters': [
+                    'masters': [
                         generate_entry(VM1),
                     ],
-                    'groups=vms': [
+                    'vms': [
                         generate_entry(VM1),
                         generate_entry(VM2),
                     ],
-                    'vm-provider=local-libvirt': [
+                    'local_libvirt': [
                         generate_entry(VM1),
                         generate_entry(VM2),
                         generate_entry(VM3),
                     ],
-                    'vm-type=default': [
+                    'default': [
                         generate_entry(VM1),
                         generate_entry(VM2),
                     ],
-                    'vm-type=not-default': [
+                    'not_default': [
                         generate_entry(VM3),
                     ],
                 }
             ), (
                 ['/disks/0/template_name', 'mgmt_net'], {
-                    '/disks/0/template_name=el7': [
+                    'el7': [
                         generate_entry(VM1),
                         generate_entry(VM2),
                     ],
-                    '/disks/0/template_name=fc25': [generate_entry(VM3)],
-                    'mgmt_net=lago': [
+                    'fc25': [generate_entry(VM3)],
+                    'lago': [
                         generate_entry(VM1),
                         generate_entry(VM2),
                         generate_entry(VM3),


### PR DESCRIPTION
The way lago generates inventory for its prefix is outdated.
This patches refreshes the algorithm to make the inventory compatible
with newer ansible versions.

Example before:

[vm-type=ovirt-engine]
lago-basic-suite-master-engine ansible_host=192.168.200.2 ansible_ssh_private_key_file=/some/key
[vm-provider=local-libvirt]
lago-basic-suite-master-engine ansible_host=192.168.200.2 ansible_ssh_private_key_file=/some/key
lago-basic-suite-master-host-0 ansible_host=192.168.200.3 ansible_ssh_private_key_file=/some/key
lago-basic-suite-master-host-1 ansible_host=192.168.200.4 ansible_ssh_private_key_file=/some/key
[vm-type=ovirt-host]
lago-basic-suite-master-host-0 ansible_host=192.168.200.3 ansible_ssh_private_key_file=/some/key
lago-basic-suite-master-host-1 ansible_host=192.168.200.4 ansible_ssh_private_key_file=/some/key

and after:

[ovirt_engine]
lago-basic-suite-master-engine ansible_host=192.168.200.2 ansible_ssh_private_key_file=/some/key
[local_libvirt]
lago-basic-suite-master-engine ansible_host=192.168.200.2 ansible_ssh_private_key_file=/some/key
lago-basic-suite-master-host-0 ansible_host=192.168.200.3 ansible_ssh_private_key_file=/some/key
lago-basic-suite-master-host-1 ansible_host=192.168.200.4 ansible_ssh_private_key_file=/some/key
[ovirt_host]
lago-basic-suite-master-host-0 ansible_host=192.168.200.3 ansible_ssh_private_key_file=/some/key
lago-basic-suite-master-host-1 ansible_host=192.168.200.4 ansible_ssh_private_key_file=/some/key

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>