### PR TITLE
libvirt: Use native io

### DIFF
--- a/lago/providers/libvirt/vm.py
+++ b/lago/providers/libvirt/vm.py
@@ -618,14 +618,19 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
                 device=disk_device,
             )
 
+            # cache='none' allows using io='native', which typically get best
+            # performance, and avoid multiple level of caching when using
+            # nested vms.
+
             if bus == 'virtio':
                 disk.append(
                     ET.Element(
                         'driver',
                         name='qemu',
                         type=dev_spec['format'],
+                        cache='none',
+                        io='native',
                         discard='unmap',
-                        cache='writeback',
                         iothread='1',
                         queues='1',
                     ),
@@ -636,8 +641,9 @@ class LocalLibvirtVMProvider(vm_plugin.VMProviderPlugin):
                         'driver',
                         name='qemu',
                         type=dev_spec['format'],
+                        cache='none',
+                        io='native',
                         discard='unmap',
-                        cache='writeback',
                     ),
                 )
             else:


### PR DESCRIPTION
Previously we use cache="writeback" (the default), resulting in multiple
level of caching when using nested vms. Replace to cache="none" as used
by oVirt.

cache="none" allow using io="native" which usually give best
performance.

Finally use assign iothread also to scsi disks, not only to virtio.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>